### PR TITLE
Support for DataMember and IgnoreDataMember attributes

### DIFF
--- a/Castle.Sharp2Js.Tests/Castle.Sharp2Js.Tests.csproj
+++ b/Castle.Sharp2Js.Tests/Castle.Sharp2Js.Tests.csproj
@@ -46,6 +46,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
+    <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">

--- a/Castle.Sharp2Js.Tests/DTOs/SampleModel.cs
+++ b/Castle.Sharp2Js.Tests/DTOs/SampleModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -15,6 +16,14 @@ namespace Castle.Sharp2Js.Tests.DTOs
     public class ArrayTypeTest
     {
         public string[] Strings { get; set; }
+    }
+
+    public class AttributeInformationTest
+    {
+        [DataMember(Name = "TestName")]
+        public string TypeName { get; set; }
+        [IgnoreDataMember]
+        public bool IgnoreMe { get; set; }
     }
 
 }

--- a/Castle.Sharp2Js.Tests/JsGeneratorTests.cs
+++ b/Castle.Sharp2Js.Tests/JsGeneratorTests.cs
@@ -16,7 +16,9 @@ namespace Castle.Sharp2Js.Tests
 
             var modelType = typeof (AddressInformation);
 
+#pragma warning disable 618
             var outputJs = JsGenerator.GenerateJsModelFromTypeWithDescendants(modelType, true, "castle");
+#pragma warning restore 618
 
             Assert.IsTrue(!string.IsNullOrEmpty(outputJs));
 
@@ -41,7 +43,9 @@ namespace Castle.Sharp2Js.Tests
 
             var modelType = typeof (RecursiveTest);
 
+#pragma warning disable 618
             var outputJs = JsGenerator.GenerateJsModelFromTypeWithDescendants(modelType, true, "castle");
+#pragma warning restore 618
 
             Assert.IsTrue(!string.IsNullOrEmpty(outputJs));
 
@@ -128,6 +132,38 @@ namespace Castle.Sharp2Js.Tests
                 CamelCase = true,
                 IncludeMergeFunction = false,
                 OutputNamespace = "models"
+            });
+
+            Assert.IsTrue(!string.IsNullOrEmpty(outputJs));
+
+            var js = new Jint.Parser.JavaScriptParser();
+
+            try
+            {
+                js.Parse(outputJs);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected no exception parsing javascript, but got: " + ex.Message);
+            }
+
+
+        }
+
+        [Test]
+        public void DataMemberAttributeHandling()
+        {
+            //Generate a basic javascript model from a C# class
+
+            var modelType = typeof(AttributeInformationTest);
+
+            var outputJs = JsGenerator.Generate(new[] { modelType }, new JsGeneratorOptions()
+            {
+                ClassNameConstantsToRemove = new List<string>() { "Dto" },
+                CamelCase = true,
+                IncludeMergeFunction = false,
+                OutputNamespace = "models",
+                RespectDataMemberAttribute = true
             });
 
             Assert.IsTrue(!string.IsNullOrEmpty(outputJs));

--- a/Castle.Sharp2Js/Castle.Sharp2Js.csproj
+++ b/Castle.Sharp2Js/Castle.Sharp2Js.csproj
@@ -22,6 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Castle.Sharp2Js.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -35,11 +36,11 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Castle.Sharp2Js/JsGeneratorOptions.cs
+++ b/Castle.Sharp2Js/JsGeneratorOptions.cs
@@ -13,27 +13,37 @@ namespace Castle.Sharp2Js
         /// <value>
         ///   <c>true</c> if [camel case]; otherwise, <c>false</c>.
         /// </value>
-        public bool CamelCase { get; set; }
+        public bool CamelCase { get; set; } = false;
+
         /// <summary>
         /// Gets or sets the output namespace of the javascript objects.
         /// </summary>
         /// <value>
         /// The output namespace.
         /// </value>
-        public string OutputNamespace { get; set; }
+        public string OutputNamespace { get; set; } = "models";
+
         /// <summary>
         /// Gets or sets a value indicating whether to include a merge function for the js objects.
         /// </summary>
         /// <value>
         /// <c>true</c> if [include merge function]; otherwise, <c>false</c>.
         /// </value>
-        public bool IncludeMergeFunction { get; set; }
+        public bool IncludeMergeFunction { get; set; } = true;
         /// <summary>
         /// Gets or sets a list of strings to remove from class names (e.g. Dto) automatically.
         /// </summary>
         /// <value>
         /// The class name constants to remove.
         /// </value>
-        public List<string> ClassNameConstantsToRemove { get; set; }
+        public List<string> ClassNameConstantsToRemove { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to respect the DataMember name attribute when present.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if [respect data member attribute]; otherwise, <c>false</c>.
+        /// </value>
+        public bool RespectDataMemberAttribute { get; set; } = true;
     }
 }

--- a/Castle.Sharp2Js/PropertyBag.cs
+++ b/Castle.Sharp2Js/PropertyBag.cs
@@ -2,13 +2,28 @@
 
 namespace Castle.Sharp2Js
 {
+    /// <summary>
+    /// Responsible for storing data about the type models to be generated
+    /// </summary>
     public class PropertyBag
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PropertyBag"/> class.
+        /// </summary>
         public PropertyBag()
         {
 
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PropertyBag"/> class.
+        /// </summary>
+        /// <param name="typeName">Name of the type.</param>
+        /// <param name="propertyName">Name of the property.</param>
+        /// <param name="propertyType">Type of the property.</param>
+        /// <param name="isArray">if set to <c>true</c> [is array].</param>
+        /// <param name="propertyTypeName">Name of the property type.</param>
+        /// <param name="isPrimitiveType">if set to <c>true</c> [is primitive type].</param>
         public PropertyBag(string typeName, string propertyName, Type propertyType,
             bool isArray, string propertyTypeName, bool isPrimitiveType)
         {
@@ -20,11 +35,47 @@ namespace Castle.Sharp2Js
             IsPrimitiveType = isPrimitiveType;
         }
 
+        /// <summary>
+        /// Gets or sets the name of the type.
+        /// </summary>
+        /// <value>
+        /// The name of the type.
+        /// </value>
         public string TypeName { get; set; }
+        /// <summary>
+        /// Gets or sets the name of the property.
+        /// </summary>
+        /// <value>
+        /// The name of the property.
+        /// </value>
         public string PropertyName { get; set; }
+        /// <summary>
+        /// Gets or sets the type of the property.
+        /// </summary>
+        /// <value>
+        /// The type of the property.
+        /// </value>
         public Type PropertyType { get; set; }
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is an array.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance is an array; otherwise, <c>false</c>.
+        /// </value>
         public bool IsArray { get; set; }
+        /// <summary>
+        /// Gets or sets the name of the property type.
+        /// </summary>
+        /// <value>
+        /// The name of the property type.
+        /// </value>
         public string PropertyTypeName { get; set; }
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is primitive type.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance is primitive type; otherwise, <c>false</c>.
+        /// </value>
         public bool IsPrimitiveType { get; set; }
 
     }

--- a/Castle.Sharp2Js/SampleData/SampleModel.cs
+++ b/Castle.Sharp2Js/SampleData/SampleModel.cs
@@ -2,26 +2,101 @@
 
 namespace Castle.Sharp2Js.SampleData
 {
+    /// <summary>
+    /// Demo class to show off some of the features of sharp2Js.
+    /// </summary>
     public class AddressInformation
     {
+        /// <summary>
+        /// Gets or sets the name.
+        /// </summary>
+        /// <value>
+        /// The name.
+        /// </value>
         public string Name { get; set; }
+        /// <summary>
+        /// Gets or sets the address.
+        /// </summary>
+        /// <value>
+        /// The address.
+        /// </value>
         public string Address { get; set; }
+        /// <summary>
+        /// Gets or sets the zip code.
+        /// </summary>
+        /// <value>
+        /// The zip code.
+        /// </value>
         public int ZipCode { get; set; }
+        /// <summary>
+        /// Gets or sets the owner.
+        /// </summary>
+        /// <value>
+        /// The owner.
+        /// </value>
         public OwnerInformation Owner { get; set; }
+        /// <summary>
+        /// Gets or sets the features.
+        /// </summary>
+        /// <value>
+        /// The features.
+        /// </value>
         public List<Feature> Features { get; set; }
+        /// <summary>
+        /// Gets or sets the tags.
+        /// </summary>
+        /// <value>
+        /// The tags.
+        /// </value>
         public List<string> Tags { get; set; }
     }
 
+    /// <summary>
+    /// Demo class to show off some of the features of sharp2Js.
+    /// </summary>
     public class OwnerInformation
     {
+        /// <summary>
+        /// Gets or sets the first name.
+        /// </summary>
+        /// <value>
+        /// The first name.
+        /// </value>
         public string FirstName { get; set; }
+        /// <summary>
+        /// Gets or sets the last name.
+        /// </summary>
+        /// <value>
+        /// The last name.
+        /// </value>
         public string LastName { get; set; }
+        /// <summary>
+        /// Gets or sets the age.
+        /// </summary>
+        /// <value>
+        /// The age.
+        /// </value>
         public int Age { get; set; }
     }
 
+    /// <summary>
+    /// Demo class to show off some of the features of sharp2Js.
+    /// </summary>
     public class Feature
     {
+        /// <summary>
+        /// Gets or sets the name.
+        /// </summary>
+        /// <value>
+        /// The name.
+        /// </value>
         public string Name { get; set; }
+        /// <summary>
+        /// Gets or sets the value.
+        /// </summary>
+        /// <value>
+        /// The value.
+        /// </value>
         public double Value { get; set; }
     }
 }


### PR DESCRIPTION
Adds support for `DataMemberAttribute` and `IgnoreDataMemberAttribute`.  If enabled in the `JsGeneratorOptions`, it will respect the `Name` property if it is set on the `DataMemberAttribute`.  Similarly, if the `IgnoreDataMemberAttribute` is detected, the member will not be processed/included in the output Js.

**Additionally, warnings are now configured to behave as errors in the Castle.Sharp2Js library.**
