### PR TITLE
Supports DefaultValue attribute, test coverage at 100%

### DIFF
--- a/Castle.Sharp2Js.Tests/DTOs/SampleModel.cs
+++ b/Castle.Sharp2Js.Tests/DTOs/SampleModel.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
@@ -7,23 +9,39 @@ using System.Threading.Tasks;
 
 namespace Castle.Sharp2Js.Tests.DTOs
 {
+    [ExcludeFromCodeCoverage]
     public class RecursiveTest
     {
         public string Name { get; set; }
         public List<RecursiveTest> RecursiveTests { get; set; }
     }
-
+    [ExcludeFromCodeCoverage]
     public class ArrayTypeTest
     {
         public string[] Strings { get; set; }
     }
-
+    [ExcludeFromCodeCoverage]
     public class AttributeInformationTest
     {
         [DataMember(Name = "TestName")]
         public string TypeName { get; set; }
         [IgnoreDataMember]
         public bool IgnoreMe { get; set; }
+        [DefaultValue(23.19)]
+        public double NumberValue1 { get; set; }
+
+        [DefaultValue("HelloWorld")]
+        public string StringValue1 { get; set; }
+
+        [DataMember(Name = " ")]
+        public string InvalidName1 { get; set; }
+
+        public List<StructTest> StructTests { get; set; }
+    }
+    [ExcludeFromCodeCoverage]
+    public struct StructTest
+    {
+        public int SructValue { get; set; }
     }
 
 }

--- a/Castle.Sharp2Js.Tests/JsGeneratorTests.cs
+++ b/Castle.Sharp2Js.Tests/JsGeneratorTests.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Castle.Sharp2Js.SampleData;
 using Castle.Sharp2Js.Tests.DTOs;
 using NUnit.Framework;
 
 namespace Castle.Sharp2Js.Tests
 {
+    [ExcludeFromCodeCoverage]
     [TestFixture]
     public class JsGeneratorTests
     {
@@ -179,6 +181,90 @@ namespace Castle.Sharp2Js.Tests
                 Assert.Fail("Expected no exception parsing javascript, but got: " + ex.Message);
             }
 
+
+        }
+
+        [Test]
+        public void DefaultValueHandling()
+        {
+            //Generate a basic javascript model from a C# class
+
+            var modelType = typeof(AttributeInformationTest);
+
+            var outputJs = JsGenerator.Generate(new[] { modelType }, new JsGeneratorOptions()
+            {
+                ClassNameConstantsToRemove = new List<string>() { "Dto" },
+                CamelCase = true,
+                IncludeMergeFunction = false,
+                OutputNamespace = "models",
+                RespectDataMemberAttribute = true,
+                RespectDefaultValueAttribute = true
+            });
+
+            Assert.IsTrue(!string.IsNullOrEmpty(outputJs));
+
+            var js = new Jint.Parser.JavaScriptParser();
+
+            try
+            {
+                js.Parse(outputJs);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected no exception parsing javascript, but got: " + ex.Message);
+            }
+
+
+        }
+
+        [Test]
+        public void UnexpectedStateHandling()
+        {
+            //Generate a basic javascript model from a C# class
+
+            var modelType = typeof(AttributeInformationTest);
+
+            var outputJs = JsGenerator.Generate(new[] { modelType }, new JsGeneratorOptions()
+            {
+                ClassNameConstantsToRemove = null,
+                CamelCase = true,
+                IncludeMergeFunction = false,
+                OutputNamespace = "models",
+                RespectDataMemberAttribute = false,
+                RespectDefaultValueAttribute = false
+            });
+
+            Assert.IsTrue(!string.IsNullOrEmpty(outputJs));
+
+            var js = new Jint.Parser.JavaScriptParser();
+
+            try
+            {
+                js.Parse(outputJs);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected no exception parsing javascript, but got: " + ex.Message);
+            }
+
+
+        }
+
+        [Test]
+        public void FatalStateHandling()
+        {
+            //Generate a basic javascript model from a C# class
+
+            var modelType = typeof(AttributeInformationTest);
+            var tempOptions = JsGenerator.Options;
+            JsGenerator.Options = null;
+
+            Assert.Catch<ArgumentNullException>((() =>
+            {
+                var outputJs = JsGenerator.Generate(new[] { modelType });
+            }), "Expected engine to throw ArguementNullException when Options are null");
+
+            JsGenerator.Options = tempOptions;
 
         }
 

--- a/Castle.Sharp2Js/JsGeneratorOptions.cs
+++ b/Castle.Sharp2Js/JsGeneratorOptions.cs
@@ -45,5 +45,13 @@ namespace Castle.Sharp2Js
         /// <c>true</c> if [respect data member attribute]; otherwise, <c>false</c>.
         /// </value>
         public bool RespectDataMemberAttribute { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to respect the DefaultValue attribute when present..
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [respect default value attribute]; otherwise, <c>false</c>.
+        /// </value>
+        public bool RespectDefaultValueAttribute { get; set; } = true;
     }
 }

--- a/Castle.Sharp2Js/PropertyBag.cs
+++ b/Castle.Sharp2Js/PropertyBag.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Castle.Sharp2Js
 {
     /// <summary>
     /// Responsible for storing data about the type models to be generated
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class PropertyBag
     {
         /// <summary>
@@ -16,7 +18,7 @@ namespace Castle.Sharp2Js
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PropertyBag"/> class.
+        /// Initializes a new instance of the <see cref="PropertyBag" /> class.
         /// </summary>
         /// <param name="typeName">Name of the type.</param>
         /// <param name="propertyName">Name of the property.</param>
@@ -24,8 +26,11 @@ namespace Castle.Sharp2Js
         /// <param name="isArray">if set to <c>true</c> [is array].</param>
         /// <param name="propertyTypeName">Name of the property type.</param>
         /// <param name="isPrimitiveType">if set to <c>true</c> [is primitive type].</param>
+        /// <param name="hasDefaultValue">if set to <c>true</c> [has default value].</param>
+        /// <param name="defaultValue">The default value.</param>
         public PropertyBag(string typeName, string propertyName, Type propertyType,
-            bool isArray, string propertyTypeName, bool isPrimitiveType)
+            bool isArray, string propertyTypeName, bool isPrimitiveType, bool hasDefaultValue,
+            object defaultValue)
         {
             TypeName = typeName;
             PropertyName = propertyName;
@@ -33,6 +38,8 @@ namespace Castle.Sharp2Js
             IsArray = isArray;
             PropertyTypeName = propertyTypeName;
             IsPrimitiveType = isPrimitiveType;
+            HasDefaultValue = hasDefaultValue;
+            DefaultValue = defaultValue;
         }
 
         /// <summary>
@@ -77,6 +84,19 @@ namespace Castle.Sharp2Js
         /// <c>true</c> if this instance is primitive type; otherwise, <c>false</c>.
         /// </value>
         public bool IsPrimitiveType { get; set; }
-
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance has a default value.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance has default value; otherwise, <c>false</c>.
+        /// </value>
+        public bool HasDefaultValue { get; set; }
+        /// <summary>
+        /// Gets or sets the default value.
+        /// </summary>
+        /// <value>
+        /// The default value.
+        /// </value>
+        public object DefaultValue { get; set; }
     }
 }

--- a/Castle.Sharp2Js/SampleData/SampleModel.cs
+++ b/Castle.Sharp2Js/SampleData/SampleModel.cs
@@ -1,10 +1,12 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Castle.Sharp2Js.SampleData
 {
     /// <summary>
     /// Demo class to show off some of the features of sharp2Js.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class AddressInformation
     {
         /// <summary>
@@ -54,6 +56,7 @@ namespace Castle.Sharp2Js.SampleData
     /// <summary>
     /// Demo class to show off some of the features of sharp2Js.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class OwnerInformation
     {
         /// <summary>
@@ -82,6 +85,7 @@ namespace Castle.Sharp2Js.SampleData
     /// <summary>
     /// Demo class to show off some of the features of sharp2Js.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class Feature
     {
         /// <summary>


### PR DESCRIPTION
Increases C# test coverage to a cool 100%.  

Adds support for the `[DefaultValue]` attribute, and sets the values accordingly during Js object construction if a value is not provided in the passed in constructor argument.
