### PR TITLE
Fixes an issue with camel casing

### DIFF
--- a/Castle.Sharp2Js.Tests/DTOs/SampleModel.cs
+++ b/Castle.Sharp2Js.Tests/DTOs/SampleModel.cs
@@ -43,5 +43,12 @@ namespace Castle.Sharp2Js.Tests.DTOs
     {
         public int SructValue { get; set; }
     }
+    [ExcludeFromCodeCoverage]
+    public class CamelCaseTest
+    {
+        public string WKTPolygon { get; set; }
+        public string alreadyUnderscored { get; set; }
+        public string RegularCased { get; set; }
+    }
 
 }

--- a/Castle.Sharp2Js.Tests/JsGeneratorTests.cs
+++ b/Castle.Sharp2Js.Tests/JsGeneratorTests.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Castle.Sharp2Js.SampleData;
 using Castle.Sharp2Js.Tests.DTOs;
+using Jint.Parser.Ast;
 using NUnit.Framework;
 
 namespace Castle.Sharp2Js.Tests
@@ -265,6 +267,84 @@ namespace Castle.Sharp2Js.Tests
             }), "Expected engine to throw ArguementNullException when Options are null");
 
             JsGenerator.Options = tempOptions;
+
+        }
+
+
+        [Test]
+        public void CamelCaseHandling()
+        {
+            //Generate a basic javascript model from a C# class
+
+            var modelType = typeof(CamelCaseTest);
+
+            var outputJs = JsGenerator.Generate(new[] { modelType }, new JsGeneratorOptions()
+            {
+                ClassNameConstantsToRemove = new List<string>() { "Dto" },
+                CamelCase = true,
+                IncludeMergeFunction = false,
+                OutputNamespace = "models",
+                RespectDataMemberAttribute = true,
+                RespectDefaultValueAttribute = true
+            });
+
+            Assert.IsTrue(!string.IsNullOrEmpty(outputJs));
+
+            var js = new Jint.Parser.JavaScriptParser();
+
+            Program res = null;
+
+            try
+            {
+                res = js.Parse(outputJs);
+
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected no exception parsing javascript, but got: " + ex.Message);
+            }
+
+
+            var classExpression = res.Body.First().As<ExpressionStatement>();
+
+            var functionDefinition =
+                classExpression.Expression.As<AssignmentExpression>().Right.As<FunctionExpression>()
+                    .Body.As<BlockStatement>()
+                    .Body;
+
+            var firstMemberDefinition =
+                functionDefinition.Skip(1)
+                    .Take(1)
+                    .First()
+                    .As<ExpressionStatement>()
+                    .Expression.As<AssignmentExpression>();
+
+            var memberName = firstMemberDefinition.Left.As<MemberExpression>().Property.As<Identifier>().Name;
+
+            Assert.IsTrue(memberName == "wktPolygon");
+
+            var secondMemberDefinition =
+                functionDefinition.Skip(2)
+                    .Take(1)
+                    .First()
+                    .As<ExpressionStatement>()
+                    .Expression.As<AssignmentExpression>();
+
+            var secondMemberName = secondMemberDefinition.Left.As<MemberExpression>().Property.As<Identifier>().Name;
+
+            Assert.IsTrue(secondMemberName == "alreadyUnderscored");
+
+            var thirdMemberDefinition =
+                functionDefinition.Skip(3)
+                    .Take(1)
+                    .First()
+                    .As<ExpressionStatement>()
+                    .Expression.As<AssignmentExpression>();
+
+            var thirdMemberName = thirdMemberDefinition.Left.As<MemberExpression>().Property.As<Identifier>().Name;
+
+            Assert.IsTrue(thirdMemberName == "regularCased");
+
 
         }
 

--- a/Castle.Sharp2Js/JsGenerator.cs
+++ b/Castle.Sharp2Js/JsGenerator.cs
@@ -256,8 +256,16 @@ namespace Castle.Sharp2Js
         {
             if (!camelCase) return input;
 
-            return input.Substring(0, 1).ToLower() +
-                input.Substring(1);
+            var s = input;
+            if (!char.IsUpper(s[0])) return s;
+
+            var cArr = s.ToCharArray();
+            for (var i = 0; i < cArr.Length; i++)
+            {
+                if (i > 0 && i + 1 < cArr.Length && !char.IsUpper(cArr[i + 1])) break;
+                cArr[i] = char.ToLowerInvariant(cArr[i]);
+            }
+            return new string(cArr);
         }
 
         /// <summary>


### PR DESCRIPTION
When more than the first letter is capitalized in a property name, only the first letter is changed to lower case, when it should actually lowercase all but the last of the letters in the series.  E.g. `WKTPolgygon` should camel case as `wktPolygon`, not `wKTPolgyon`.
