### PR TITLE
Adds support for all Data Contract collection types 

### DIFF
--- a/Castle.Sharp2Js.Tests/Castle.Sharp2Js.Tests.csproj
+++ b/Castle.Sharp2Js.Tests/Castle.Sharp2Js.Tests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Castle.Sharp2Js.Tests</RootNamespace>
     <AssemblyName>Castle.Sharp2Js.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -26,6 +26,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -34,14 +35,23 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Jil, Version=2.12.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Jil.2.12.1\lib\net45\Jil.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Jint, Version=2.6.0.0, Culture=neutral, PublicKeyToken=2e92ba9c8d81157f, processorArchitecture=MSIL">
       <HintPath>..\packages\Jint.2.6.0\lib\portable-net40+sl50+win+WindowsPhoneApp81+wp80\Jint.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Sigil, Version=4.5.0.0, Culture=neutral, PublicKeyToken=2d06c3494341c8ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sigil.4.5.0\lib\net45\Sigil.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -60,6 +70,7 @@
     <Compile Include="DTOs\SampleModel.cs" />
     <Compile Include="JsGeneratorTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SerializerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Castle.Sharp2Js\Castle.Sharp2Js.csproj">

--- a/Castle.Sharp2Js.Tests/DTOs/SampleModel.cs
+++ b/Castle.Sharp2Js.Tests/DTOs/SampleModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
@@ -50,5 +51,112 @@ namespace Castle.Sharp2Js.Tests.DTOs
         public string alreadyUnderscored { get; set; }
         public string RegularCased { get; set; }
     }
+    [ExcludeFromCodeCoverage]
+    public class CustomListTest<T> : IList
+    {
+        private List<T> _privateList = new List<T>();
+        public IEnumerator GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void CopyTo(Array array, int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int Count
+        {
+            get { return _privateList.Count; }
+        }
+
+        public object SyncRoot
+        {
+            get { return _privateList; }
+        }
+
+        public bool IsSynchronized
+        {
+            get { return true; }
+        }
+
+        public int Add(object value)
+        {
+            _privateList.Add((T)value);
+            return _privateList.Count;
+        }
+
+        public bool Contains(object value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotImplementedException();
+        }
+
+        public int IndexOf(object value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Insert(int index, object value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Remove(object value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object this[int index]
+        {
+            get { return _privateList[index]; }
+            set { throw new NotImplementedException(); }
+        }
+
+        public bool IsReadOnly
+        {
+            get { return false; }
+        }
+
+        public bool IsFixedSize
+        {
+            get { return false; }
+        }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class CollectionTesting
+    {
+        public List<string> ListCollection { get; set; }
+
+        public CollectionTesting[] ObjectArrayCollection { get; set; }
+
+        public ArrayList ArrayListCollection { get; set; }
+
+        public Dictionary<string, string> DictionaryCollection { get; set; }
+
+        public Dictionary<string, ArrayTypeTest> DictionaryObjectCollection { get; set; }
+
+        public CustomListTest<string> CustomListCollection { get; set; }
+
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class DictionaryKeyTesting
+    {
+        public Dictionary<ArrayTypeTest, string> DictionaryObjectKeyCollection { get; set; }
+
+    }
+
+
 
 }

--- a/Castle.Sharp2Js.Tests/JsGeneratorTests.cs
+++ b/Castle.Sharp2Js.Tests/JsGeneratorTests.cs
@@ -348,6 +348,78 @@ namespace Castle.Sharp2Js.Tests
 
         }
 
+
+        [Test]
+        public void InvalidDictionaryKeyHandling()
+        {
+            //Generate a basic javascript model from a C# class
+
+            var modelType = typeof(DictionaryKeyTesting);
+
+
+            var codeRanThrough = false;
+            try
+            {
+                JsGenerator.Generate(new[] { modelType }, new JsGeneratorOptions()
+                {
+                    ClassNameConstantsToRemove = null,
+                    CamelCase = true,
+                    IncludeMergeFunction = false,
+                    OutputNamespace = "models",
+                    RespectDataMemberAttribute = false,
+                    RespectDefaultValueAttribute = false
+                });
+
+                codeRanThrough = true;
+
+            }
+            catch (Exception)
+            {
+                Assert.Pass();
+            }
+
+            if (codeRanThrough)
+            {
+                Assert.Fail("Expected exception generating type with incompatible dictionary key type.");
+            }
+
+        }
+
+        [Test]
+        public void CollectionHandling()
+        {
+            //Generate a basic javascript model from a C# class
+
+            var modelType = typeof(CollectionTesting);
+
+            var outputJs = JsGenerator.Generate(new[] { modelType }, new JsGeneratorOptions()
+            {
+                ClassNameConstantsToRemove = new List<string>() { "Dto" },
+                CamelCase = true,
+                IncludeMergeFunction = true,
+                OutputNamespace = "models",
+                RespectDataMemberAttribute = true,
+                RespectDefaultValueAttribute = true
+            });
+
+            Assert.IsTrue(!string.IsNullOrEmpty(outputJs));
+
+            var js = new Jint.Parser.JavaScriptParser();
+
+            
+
+            try
+            {
+                js.Parse(outputJs);
+
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected no exception parsing javascript, but got: " + ex.Message);
+            }
+
+        }
+
     }
 
     

--- a/Castle.Sharp2Js.Tests/SerializerTests.cs
+++ b/Castle.Sharp2Js.Tests/SerializerTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using Castle.Sharp2Js.Tests.DTOs;
+using NUnit.Framework;
+using NUnit.Framework.Constraints;
+
+namespace Castle.Sharp2Js.Tests
+{
+    [ExcludeFromCodeCoverage]
+    [TestFixture]
+    public class SerializerTests
+    {
+        [Test]
+        public void TestJilCollectionSerialization()
+        {
+            var collectionObj = new CollectionTesting()
+            {
+                ArrayListCollection = new ArrayList() {"Object1", "Object2"},
+                CustomListCollection = new CustomListTest<string>() {"Item1", "Item2"},
+                DictionaryCollection = new Dictionary<string, string>() {},
+                ListCollection = new List<string>() { "Item 1", "Item 2" },
+                ObjectArrayCollection = new [] { new CollectionTesting() }
+            };
+
+            collectionObj.DictionaryCollection.Add("Key 1", "Value 1");
+            collectionObj.DictionaryCollection.Add("Key 2", "Value 2");
+
+            string res = Jil.JSON.Serialize(collectionObj);
+        }
+    }
+}

--- a/Castle.Sharp2Js.Tests/packages.config
+++ b/Castle.Sharp2Js.Tests/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Jil" version="2.12.1" targetFramework="net45" />
   <package id="Jint" version="2.6.0" targetFramework="net452" />
   <package id="NUnit" version="2.6.4" targetFramework="net4" />
+  <package id="Sigil" version="4.5.0" targetFramework="net45" />
 </packages>

--- a/Castle.Sharp2Js/Castle.Sharp2Js.csproj
+++ b/Castle.Sharp2Js/Castle.Sharp2Js.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Castle.Sharp2Js</RootNamespace>
     <AssemblyName>Castle.Sharp2Js</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -23,6 +23,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Castle.Sharp2Js.xml</DocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,6 +33,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Castle.Sharp2Js.xml</DocumentationFile>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Castle.Sharp2Js/PropertyBag.cs
+++ b/Castle.Sharp2Js/PropertyBag.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Castle.Sharp2Js
@@ -10,36 +11,27 @@ namespace Castle.Sharp2Js
     public class PropertyBag
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="PropertyBag"/> class.
-        /// </summary>
-        public PropertyBag()
-        {
-
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="PropertyBag" /> class.
         /// </summary>
         /// <param name="typeName">Name of the type.</param>
         /// <param name="propertyName">Name of the property.</param>
         /// <param name="propertyType">Type of the property.</param>
-        /// <param name="isArray">if set to <c>true</c> [is array].</param>
-        /// <param name="propertyTypeName">Name of the property type.</param>
-        /// <param name="isPrimitiveType">if set to <c>true</c> [is primitive type].</param>
+        /// <param name="collectionInnerTypes">The collection inner types.</param>
+        /// <param name="transformablePropertyType">Type of the transformable property.</param>
         /// <param name="hasDefaultValue">if set to <c>true</c> [has default value].</param>
         /// <param name="defaultValue">The default value.</param>
         public PropertyBag(string typeName, string propertyName, Type propertyType,
-            bool isArray, string propertyTypeName, bool isPrimitiveType, bool hasDefaultValue,
-            object defaultValue)
+            List<PropertyBagTypeInfo> collectionInnerTypes, 
+            TransformablePropertyTypeEnum transformablePropertyType,
+            bool hasDefaultValue, object defaultValue)
         {
             TypeName = typeName;
             PropertyName = propertyName;
             PropertyType = propertyType;
-            IsArray = isArray;
-            PropertyTypeName = propertyTypeName;
-            IsPrimitiveType = isPrimitiveType;
+            CollectionInnerTypes = collectionInnerTypes;
             HasDefaultValue = hasDefaultValue;
             DefaultValue = defaultValue;
+            TransformablePropertyType = transformablePropertyType;
         }
 
         /// <summary>
@@ -64,26 +56,20 @@ namespace Castle.Sharp2Js
         /// </value>
         public Type PropertyType { get; set; }
         /// <summary>
-        /// Gets or sets a value indicating whether this instance is an array.
+        /// Determines what class of object the transformer treats the object as 
+        /// which determines how the pieces are treated when writing Js objects.
         /// </summary>
         /// <value>
-        ///   <c>true</c> if this instance is an array; otherwise, <c>false</c>.
+        /// The type of the transformable property.
         /// </value>
-        public bool IsArray { get; set; }
+        public TransformablePropertyTypeEnum TransformablePropertyType { get; set; }
         /// <summary>
         /// Gets or sets the name of the property type.
         /// </summary>
         /// <value>
         /// The name of the property type.
         /// </value>
-        public string PropertyTypeName { get; set; }
-        /// <summary>
-        /// Gets or sets a value indicating whether this instance is primitive type.
-        /// </summary>
-        /// <value>
-        /// <c>true</c> if this instance is primitive type; otherwise, <c>false</c>.
-        /// </value>
-        public bool IsPrimitiveType { get; set; }
+        public List<PropertyBagTypeInfo> CollectionInnerTypes { get; set; }
         /// <summary>
         /// Gets or sets a value indicating whether this instance has a default value.
         /// </summary>
@@ -98,5 +84,58 @@ namespace Castle.Sharp2Js
         /// The default value.
         /// </value>
         public object DefaultValue { get; set; }
+
+
+        /// <summary>
+        /// Transformable property types understood by sharp2Js
+        /// </summary>
+        public enum TransformablePropertyTypeEnum
+        {
+            /// <summary>
+            /// The primitive
+            /// </summary>
+            Primitive = 1,
+            /// <summary>
+            /// The collection type
+            /// </summary>
+            CollectionType = 2,
+            /// <summary>
+            /// The dictionary type
+            /// </summary>
+            DictionaryType = 3,
+            /// <summary>
+            /// The reference type
+            /// </summary>
+            ReferenceType = 4
+        }
     }
+    /// <summary>
+    /// Contains types contained within collections and designations for dictionary types
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public class PropertyBagTypeInfo
+    {
+        /// <summary>
+        /// Gets or sets the type.
+        /// </summary>
+        /// <value>
+        /// The type.
+        /// </value>
+        public Type Type { get; set; }
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is the dictionary key.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance is the dictionary key; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsDictionaryKey { get; set; }
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is primitive type.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance is primitive type; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsPrimitiveType { get; set; }
+    }
+    
 }


### PR DESCRIPTION
Adds support for types that implement IList, ICollection, or IDictionary as well as standard array types.

Additionally, refactors some things to make the growing changes a little more manageable.
