### PR TITLE
Added action delegates for custom function parsers.  Moved to .Net 4.5 Target

### DIFF
--- a/Castle.Sharp2Js.Tests/JsGeneratorTests.cs
+++ b/Castle.Sharp2Js.Tests/JsGeneratorTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Text;
 using Castle.Sharp2Js.SampleData;
 using Castle.Sharp2Js.Tests.DTOs;
 using Jint.Parser.Ast;
@@ -407,6 +408,55 @@ namespace Castle.Sharp2Js.Tests
             var js = new Jint.Parser.JavaScriptParser();
 
             
+
+            try
+            {
+                js.Parse(outputJs);
+
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected no exception parsing javascript, but got: " + ex.Message);
+            }
+
+        }
+
+        [Test]
+        public void CustomFunctionHandling()
+        {
+            //Generate a basic javascript model from a C# class
+
+            var modelType = typeof(CollectionTesting);
+
+            var outputJs = JsGenerator.Generate(new[] {modelType}, new JsGeneratorOptions()
+            {
+                ClassNameConstantsToRemove = new List<string>() {"Dto"},
+                CamelCase = true,
+                IncludeMergeFunction = true,
+                OutputNamespace = "models",
+                RespectDataMemberAttribute = true,
+                RespectDefaultValueAttribute = true,
+                CustomFunctionProcessors =
+                    new List<Action<StringBuilder, IEnumerable<PropertyBag>, JsGeneratorOptions>>()
+                    {
+                        (builder, bags, arg3) =>
+                        {
+                            builder.AppendLine($"\tthis.helloWorld = function () {{");
+                            builder.AppendLine("\t\tconsole.log('hello');");
+                            builder.AppendLine("\t}");
+                        }
+                    }
+            });
+
+            
+
+            Assert.IsTrue(!string.IsNullOrEmpty(outputJs));
+
+            Assert.IsTrue(outputJs.Contains("this.helloWorld"));
+
+            var js = new Jint.Parser.JavaScriptParser();
+
+
 
             try
             {

--- a/Castle.Sharp2Js/JsGeneratorOptions.cs
+++ b/Castle.Sharp2Js/JsGeneratorOptions.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
 
 namespace Castle.Sharp2Js
 {
@@ -47,11 +49,19 @@ namespace Castle.Sharp2Js
         public bool RespectDataMemberAttribute { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets a value indicating whether to respect the DefaultValue attribute when present..
+        /// Gets or sets a value indicating whether to respect the DefaultValue attribute when present.
         /// </summary>
         /// <value>
         ///   <c>true</c> if [respect default value attribute]; otherwise, <c>false</c>.
         /// </value>
         public bool RespectDefaultValueAttribute { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the custom function processors that can be run per type.
+        /// </summary>
+        /// <value>
+        /// The custom function processors.
+        /// </value>
+        public List<Action<StringBuilder, IEnumerable<PropertyBag>, JsGeneratorOptions>> CustomFunctionProcessors { get; set; }
     }
 }


### PR DESCRIPTION
Custom function can now be added like so:

```
var outputJs = JsGenerator.Generate(new[] {modelType}, new JsGeneratorOptions()
            {
                ClassNameConstantsToRemove = new List<string>() {"Dto"},
                CamelCase = true,
                IncludeMergeFunction = true,
                OutputNamespace = "models",
                RespectDataMemberAttribute = true,
                RespectDefaultValueAttribute = true,
                CustomFunctionProcessors =
                new List<Action<StringBuilder, IEnumerable<PropertyBag>, JsGeneratorOptions>>()
                {
                    (builder, bags, arg3) =>
                    {
                        builder.AppendLine($"\tthis.helloWorld = function () {{");
                        builder.AppendLine("\t\tconsole.log('hello');");
                        builder.AppendLine("\t}");
                    }
                }
        });
```

Produces:

```
models.ReflectedClass = function (cons, overrideObj) {
    if (!overrideObj) { overrideObj = { }; }
    if (!cons) { cons = { }; }
    var i, length;

    ...

    this.helloWorld = function () {
        console.log('hello');
    }
}
```

Moved to .Net 4.5 to stay with the times :)
