### PR TITLE
Adds support for enums

### DIFF
--- a/Castle.Sharp2Js.Tests/Castle.Sharp2Js.Tests.csproj
+++ b/Castle.Sharp2Js.Tests/Castle.Sharp2Js.Tests.csproj
@@ -46,6 +46,10 @@
       <HintPath>..\packages\Jint.2.6.0\lib\portable-net40+sl50+win+WindowsPhoneApp81+wp80\Jint.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>

--- a/Castle.Sharp2Js.Tests/DTOs/SampleModel.cs
+++ b/Castle.Sharp2Js.Tests/DTOs/SampleModel.cs
@@ -157,6 +157,23 @@ namespace Castle.Sharp2Js.Tests.DTOs
 
     }
 
+    [ExcludeFromCodeCoverage]
+    public class EnumTesting
+    {
+        public EnumTest1 EnumTest1 { get; set; }
+        public EnumTest2 EnumTest2 { get; set; }
+    }
 
+    public enum EnumTest1
+    {
+        EnumVal1,
+        EnumVal2
+    }
+
+    public enum EnumTest2
+    {
+        EnumVal1 = 1,
+        EnumVal2 = 2
+    }
 
 }

--- a/Castle.Sharp2Js.Tests/JsGeneratorTests.cs
+++ b/Castle.Sharp2Js.Tests/JsGeneratorTests.cs
@@ -470,6 +470,72 @@ namespace Castle.Sharp2Js.Tests
 
         }
 
+        [Test]
+        public void EnumHandling()
+        {
+            //Generate a basic javascript model from a C# class
+
+            var modelType = typeof(EnumTesting);
+
+            var js = new Jint.Parser.JavaScriptParser();
+
+            var outputJs = JsGenerator.Generate(new[] { modelType }, new JsGeneratorOptions()
+            {
+                ClassNameConstantsToRemove = new List<string>() { "Dto" },
+                CamelCase = true,
+                IncludeMergeFunction = true,
+                OutputNamespace = "models",
+                RespectDataMemberAttribute = true,
+                RespectDefaultValueAttribute = true,
+                
+            });
+
+
+
+            Assert.IsTrue(!string.IsNullOrEmpty(outputJs));
+
+            try
+            {
+                js.Parse(outputJs);
+
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected no exception parsing javascript, but got: " + ex.Message);
+            }
+
+            outputJs = JsGenerator.Generate(new[] { modelType }, new JsGeneratorOptions()
+            {
+                ClassNameConstantsToRemove = new List<string>() { "Dto" },
+                CamelCase = true,
+                IncludeMergeFunction = true,
+                OutputNamespace = "models",
+                RespectDataMemberAttribute = true,
+                RespectDefaultValueAttribute = true,
+                TreatEnumsAsStrings = true
+            });
+
+
+
+            Assert.IsTrue(!string.IsNullOrEmpty(outputJs));
+
+
+            
+
+
+
+            try
+            {
+                js.Parse(outputJs);
+
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected no exception parsing javascript, but got: " + ex.Message);
+            }
+
+        }
+
     }
 
     

--- a/Castle.Sharp2Js.Tests/SerializerTests.cs
+++ b/Castle.Sharp2Js.Tests/SerializerTests.cs
@@ -31,5 +31,33 @@ namespace Castle.Sharp2Js.Tests
 
             string res = Jil.JSON.Serialize(collectionObj);
         }
+
+        [Test]
+        public void TestJilEnumSerialization()
+        {
+            var collectionObj = new EnumTesting()
+            {
+                EnumTest1 = EnumTest1.EnumVal1,
+                EnumTest2 = EnumTest2.EnumVal2
+            };
+
+            
+
+            string res = Jil.JSON.Serialize(collectionObj);
+        }
+
+        [Test]
+        public void TestNewtonSoftEnumSerialization()
+        {
+            var collectionObj = new EnumTesting()
+            {
+                EnumTest1 = EnumTest1.EnumVal2,
+                EnumTest2 = EnumTest2.EnumVal2
+            };
+
+            
+
+            string res = Newtonsoft.Json.JsonConvert.SerializeObject(collectionObj);
+        }
     }
 }

--- a/Castle.Sharp2Js.Tests/packages.config
+++ b/Castle.Sharp2Js.Tests/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Jil" version="2.12.1" targetFramework="net45" />
   <package id="Jint" version="2.6.0" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net4" />
   <package id="Sigil" version="4.5.0" targetFramework="net45" />
 </packages>

--- a/Castle.Sharp2Js/JsGeneratorOptions.cs
+++ b/Castle.Sharp2Js/JsGeneratorOptions.cs
@@ -63,5 +63,13 @@ namespace Castle.Sharp2Js
         /// The custom function processors.
         /// </value>
         public List<Action<StringBuilder, IEnumerable<PropertyBag>, JsGeneratorOptions>> CustomFunctionProcessors { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether enum values should be treated as strings (the default for serializers like Jil) instead of ints.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [treat enums as strings]; otherwise, <c>false</c>.
+        /// </value>
+        public bool TreatEnumsAsStrings { get; set; }
     }
 }

--- a/Castle.Sharp2Js/PropertyBag.cs
+++ b/Castle.Sharp2Js/PropertyBag.cs
@@ -14,13 +14,14 @@ namespace Castle.Sharp2Js
         /// Initializes a new instance of the <see cref="PropertyBag" /> class.
         /// </summary>
         /// <param name="typeName">Name of the type.</param>
+        /// <param name="typeDefinition">The type definition.</param>
         /// <param name="propertyName">Name of the property.</param>
         /// <param name="propertyType">Type of the property.</param>
         /// <param name="collectionInnerTypes">The collection inner types.</param>
         /// <param name="transformablePropertyType">Type of the transformable property.</param>
         /// <param name="hasDefaultValue">if set to <c>true</c> [has default value].</param>
         /// <param name="defaultValue">The default value.</param>
-        public PropertyBag(string typeName, string propertyName, Type propertyType,
+        public PropertyBag(string typeName, Type typeDefinition, string propertyName, Type propertyType,
             List<PropertyBagTypeInfo> collectionInnerTypes, 
             TransformablePropertyTypeEnum transformablePropertyType,
             bool hasDefaultValue, object defaultValue)
@@ -32,6 +33,7 @@ namespace Castle.Sharp2Js
             HasDefaultValue = hasDefaultValue;
             DefaultValue = defaultValue;
             TransformablePropertyType = transformablePropertyType;
+            TypeDefinition = typeDefinition;
         }
 
         /// <summary>
@@ -84,7 +86,13 @@ namespace Castle.Sharp2Js
         /// The default value.
         /// </value>
         public object DefaultValue { get; set; }
-
+        /// <summary>
+        /// Gets or sets the type definition.
+        /// </summary>
+        /// <value>
+        /// The type definition.
+        /// </value>
+        public Type TypeDefinition { get; set; }
 
         /// <summary>
         /// Transformable property types understood by sharp2Js
@@ -136,6 +144,14 @@ namespace Castle.Sharp2Js
         /// <c>true</c> if this instance is primitive type; otherwise, <c>false</c>.
         /// </value>
         public bool IsPrimitiveType { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is enum type.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance is enum type; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsEnumType { get; set; }
     }
     
 }


### PR DESCRIPTION
Adss support for enums and allows for configurable handling of strings/vs ints.  Newtonsoft JSON.Net treats enums as numbers by default, and Jil treats enums as strings by default.  Use the `TreatEnumsAsStrings` option to configure output accordingly.
