### PR TITLE
Release 1.3

### DIFF
--- a/Castle.Sharp2Js.Nuget/Castle.Sharp2Js.Nuget.csproj
+++ b/Castle.Sharp2Js.Nuget/Castle.Sharp2Js.Nuget.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Castle.Sharp2Js.Nuget</RootNamespace>
     <AssemblyName>Castle.Sharp2Js.Nuget</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
@@ -37,10 +37,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <OutputPath>bin\Debug\</OutputPath>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <OutputPath>bin\Release\</OutputPath>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />
@@ -63,12 +65,6 @@
     <Folder Include="src\" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Castle.Sharp2JS\Castle.Sharp2Js.csproj">
-      <Project>{c9ccb675-668d-48ff-ad47-7e2d9eda49e1}</Project>
-      <Name>Castle.Sharp2Js</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="content\Sample-sharp2Js.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Sample-sharp2Js.js</LastGenOutput>
@@ -76,6 +72,12 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Castle.Sharp2Js\Castle.Sharp2Js.csproj">
+      <Project>{c9ccb675-668d-48ff-ad47-7e2d9eda49e1}</Project>
+      <Name>Castle.Sharp2Js</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Castle.Sharp2Js.Nuget/Package.nuspec
+++ b/Castle.Sharp2Js.Nuget/Package.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>sharp2Js</id>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
     <title>sharp2Js</title>
     <authors>Grant Hamm, Jared Kremer</authors>
     <owners>Castle Worldwide, Inc</owners>

--- a/Castle.Sharp2Js.Nuget/content/Sample-sharp2Js.tt
+++ b/Castle.Sharp2Js.Nuget/content/Sample-sharp2Js.tt
@@ -6,7 +6,32 @@
 <#@ output extension=".js" #>
 <#@ assembly name="$(ProjectDir)bin\$(ConfigurationName)\Castle.Sharp2Js.dll" #>
 <#@ output extension=".js" #>
-<# var str = Castle.Sharp2Js.JsGenerator.Generate(new [] { typeof(Castle.Sharp2Js.SampleData.AddressInformation) }); #>
+<#
+	//An example using most of the options
+	//var options = new Castle.Sharp2Js.JsGeneratorOptions() {
+	//	  CamelCase = false,
+	//	  OutputNamespace = "models",
+	//	  IncludeMergeFunction = true,
+	//	  ClassNameConstantsToRemove = new List<string>() { "Dto" },
+	//	  RespectDataMemberAttribute = true,
+	//	  RespectDefaultValueAttribute = true,
+	//	  TreatEnumsAsStrings = false,
+	//	  CustomFunctionProcessors =
+    //            new List<Action<StringBuilder, IEnumerable<Castle.Sharp2Js.PropertyBag>, Castle.Sharp2Js.JsGeneratorOptions>>()
+    //            {
+    //                (builder, bags, arg3) =>
+    //                {
+    //                    builder.AppendLine("\tthis.helloWorld = function () {");
+    //                    builder.AppendLine("\t\tconsole.log('hello');");
+    //                    builder.AppendLine("\t}");
+    //                }
+    //            }
+	//};
+	//var str = Castle.Sharp2Js.JsGenerator.Generate(new [] { typeof(Castle.Sharp2Js.SampleData.AddressInformation) }, options);
+
+	//An example using the default options
+	var str = Castle.Sharp2Js.JsGenerator.Generate(new [] { typeof(Castle.Sharp2Js.SampleData.AddressInformation) });
+ #>
 models = {};
 
 <#=str#>

--- a/Castle.Sharp2Js.Nuget/lib/Castle.Sharp2Js.xml
+++ b/Castle.Sharp2Js.Nuget/lib/Castle.Sharp2Js.xml
@@ -4,6 +4,79 @@
         <name>Castle.Sharp2Js</name>
     </assembly>
     <members>
+        <member name="T:Castle.Sharp2Js.Helpers">
+            <summary>
+            Helper functions for Js Generator
+            </summary>
+        </member>
+        <member name="M:Castle.Sharp2Js.Helpers.GetName(System.String,System.Collections.Generic.List{System.String})">
+            <summary>
+            Gets the name, filtering out the strings provided.
+            </summary>
+            <param name="input">The input.</param>
+            <param name="nameFilters">The name filters.</param>
+            <returns></returns>
+        </member>
+        <member name="M:Castle.Sharp2Js.Helpers.ToCamelCase(System.String,System.Boolean)">
+            <summary>
+            Camel cases an input string.
+            </summary>
+            <param name="input">The string.</param>
+            <param name="camelCase">if set to <c>true</c> [camel case].</param>
+            <returns></returns>
+        </member>
+        <member name="M:Castle.Sharp2Js.Helpers.IsCollectionType(System.Type)">
+            <summary>
+            Determines whether the specified property type is a collection.
+            </summary>
+            <param name="propertyType">Type of the property.</param>
+            <returns></returns>
+        </member>
+        <member name="M:Castle.Sharp2Js.Helpers.IsDictionaryType(System.Type)">
+            <summary>
+            Determines whether the specified property type is a dictionary.
+            </summary>
+            <param name="propertyType">Type of the property.</param>
+            <returns></returns>
+        </member>
+        <member name="M:Castle.Sharp2Js.Helpers.IsPrimitive(System.Type)">
+            <summary>
+            Determines whether the specified property type is primitive.
+            </summary>
+            <param name="propertyType">Type of the property.</param>
+            <returns></returns>
+        </member>
+        <member name="M:Castle.Sharp2Js.Helpers.ShouldGenerateMember(System.Reflection.PropertyInfo,Castle.Sharp2Js.JsGeneratorOptions)">
+            <summary>
+            Determines whether the property should be generated in the Js model.
+            </summary>
+            <param name="propertyInfo">The property information.</param>
+            <param name="generatorOptions">The generator options.</param>
+            <returns></returns>
+        </member>
+        <member name="M:Castle.Sharp2Js.Helpers.HasDefaultValue(System.Reflection.PropertyInfo,Castle.Sharp2Js.JsGeneratorOptions)">
+            <summary>
+            Determines whether the property has a default value specified by the DefaultValue attribute.
+            </summary>
+            <param name="propertyInfo">The property information.</param>
+            <param name="generatorOptions">The generator options.</param>
+            <returns></returns>
+        </member>
+        <member name="M:Castle.Sharp2Js.Helpers.ReadDefaultValueFromAttribute(System.Reflection.PropertyInfo)">
+            <summary>
+            Reads the default value from the attribute.
+            </summary>
+            <param name="propertyInfo">The property information.</param>
+            <returns></returns>
+        </member>
+        <member name="M:Castle.Sharp2Js.Helpers.GetPropertyName(System.Reflection.PropertyInfo,Castle.Sharp2Js.JsGeneratorOptions)">
+            <summary>
+            Gets the name of the property.
+            </summary>
+            <param name="propertyInfo">The property information.</param>
+            <param name="generatorOptions">The generator options.</param>
+            <returns></returns>
+        </member>
         <member name="T:Castle.Sharp2Js.JsGenerator">
             <summary>
             Converts C# classes to javascript objects for use across application tiers and in REST calls, etc.
@@ -42,30 +115,59 @@
             <param name="generationOptions">The generation options.</param>
             <returns></returns>
         </member>
-        <member name="M:Castle.Sharp2Js.JsGenerator.GetName(System.String,System.Collections.Generic.List{System.String})">
+        <member name="M:Castle.Sharp2Js.JsGenerator.BuildClassClosure(System.Text.StringBuilder)">
             <summary>
-            Gets the name, filtering out the strings provided.
+            Builds the Js class closure.
             </summary>
-            <param name="input">The input.</param>
-            <param name="nameFilters">The name filters.</param>
-            <returns></returns>
+            <param name="sb">The string builder.</param>
         </member>
-        <member name="M:Castle.Sharp2Js.JsGenerator.ToCamelCase(System.String,System.Boolean)">
+        <member name="M:Castle.Sharp2Js.JsGenerator.BuildClassConstructor(System.Linq.IGrouping{System.String,Castle.Sharp2Js.PropertyBag},System.Text.StringBuilder,Castle.Sharp2Js.JsGeneratorOptions)">
             <summary>
-            Camel cases an input string.
+            Builds the class constructor.
             </summary>
-            <param name="input">The string.</param>
-            <param name="camelCase">if set to <c>true</c> [camel case].</param>
-            <returns></returns>
+            <param name="type">The type.</param>
+            <param name="sb">The string builder.</param>
+            <param name="options">The options.</param>
         </member>
-        <member name="M:Castle.Sharp2Js.JsGenerator.GetPropertyDictionaryForTypeGeneration(System.Collections.Generic.IEnumerable{System.Type},Castle.Sharp2Js.JsGeneratorOptions,System.Collections.Generic.List{Castle.Sharp2Js.PropertyBag})">
+        <member name="M:Castle.Sharp2Js.JsGenerator.BuildMergeFunctionForClass(System.Text.StringBuilder,System.Collections.Generic.IEnumerable{Castle.Sharp2Js.PropertyBag},Castle.Sharp2Js.JsGeneratorOptions)">
             <summary>
-            Gets the property dictionary to be used for type generation.
+            Builds the merge function for a type.
             </summary>
-            <param name="types">The types to generate property information for.</param>
-            <param name="generatorOptions">The generator options.</param>
-            <param name="propertyTypeCollection">The output collection of properties discovered through reflection of the supplied classes.</param>
-            <returns></returns>
+            <param name="sb">The string builder.</param>
+            <param name="propList">The property list.</param>
+            <param name="options">The options.</param>
+        </member>
+        <member name="M:Castle.Sharp2Js.JsGenerator.BuildPrimitiveProperty(Castle.Sharp2Js.PropertyBag,System.Text.StringBuilder,Castle.Sharp2Js.JsGeneratorOptions)">
+            <summary>
+            Builds a primitive property.
+            </summary>
+            <param name="propEntry">The property entry.</param>
+            <param name="sb">The string builder.</param>
+            <param name="options">The options.</param>
+        </member>
+        <member name="M:Castle.Sharp2Js.JsGenerator.BuildObjectProperty(System.Text.StringBuilder,Castle.Sharp2Js.PropertyBag,Castle.Sharp2Js.JsGeneratorOptions)">
+            <summary>
+            Builds an object/reference property.
+            </summary>
+            <param name="sb">The string builder.</param>
+            <param name="propEntry">The property entry.</param>
+            <param name="options">The options.</param>
+        </member>
+        <member name="M:Castle.Sharp2Js.JsGenerator.BuildArrayProperty(System.Text.StringBuilder,Castle.Sharp2Js.PropertyBag,Castle.Sharp2Js.JsGeneratorOptions)">
+            <summary>
+            Builds an array property.
+            </summary>
+            <param name="sb">The string builder.</param>
+            <param name="propEntry">The property entry.</param>
+            <param name="options">The options.</param>
+        </member>
+        <member name="M:Castle.Sharp2Js.JsGenerator.BuildDictionaryProperty(System.Text.StringBuilder,Castle.Sharp2Js.PropertyBag,Castle.Sharp2Js.JsGeneratorOptions)">
+            <summary>
+            Builds a dictionary property.
+            </summary>
+            <param name="sb">The string builder.</param>
+            <param name="propEntry">The property entry.</param>
+            <param name="options">The options.</param>
         </member>
         <member name="T:Castle.Sharp2Js.JsGeneratorOptions">
             <summary>
@@ -114,10 +216,26 @@
         </member>
         <member name="P:Castle.Sharp2Js.JsGeneratorOptions.RespectDefaultValueAttribute">
             <summary>
-            Gets or sets a value indicating whether to respect the DefaultValue attribute when present..
+            Gets or sets a value indicating whether to respect the DefaultValue attribute when present.
             </summary>
             <value>
               <c>true</c> if [respect default value attribute]; otherwise, <c>false</c>.
+            </value>
+        </member>
+        <member name="P:Castle.Sharp2Js.JsGeneratorOptions.CustomFunctionProcessors">
+            <summary>
+            Gets or sets the custom function processors that can be run per type.
+            </summary>
+            <value>
+            The custom function processors.
+            </value>
+        </member>
+        <member name="P:Castle.Sharp2Js.JsGeneratorOptions.TreatEnumsAsStrings">
+            <summary>
+            Gets or sets a value indicating whether enum values should be treated as strings (the default for serializers like Jil) instead of ints.
+            </summary>
+            <value>
+              <c>true</c> if [treat enums as strings]; otherwise, <c>false</c>.
             </value>
         </member>
         <member name="T:Castle.Sharp2Js.PropertyBag">
@@ -125,21 +243,16 @@
             Responsible for storing data about the type models to be generated
             </summary>
         </member>
-        <member name="M:Castle.Sharp2Js.PropertyBag.#ctor">
-            <summary>
-            Initializes a new instance of the <see cref="T:Castle.Sharp2Js.PropertyBag"/> class.
-            </summary>
-        </member>
-        <member name="M:Castle.Sharp2Js.PropertyBag.#ctor(System.String,System.String,System.Type,System.Boolean,System.String,System.Boolean,System.Boolean,System.Object)">
+        <member name="M:Castle.Sharp2Js.PropertyBag.#ctor(System.String,System.Type,System.String,System.Type,System.Collections.Generic.List{Castle.Sharp2Js.PropertyBagTypeInfo},Castle.Sharp2Js.PropertyBag.TransformablePropertyTypeEnum,System.Boolean,System.Object)">
             <summary>
             Initializes a new instance of the <see cref="T:Castle.Sharp2Js.PropertyBag" /> class.
             </summary>
             <param name="typeName">Name of the type.</param>
+            <param name="typeDefinition">The type definition.</param>
             <param name="propertyName">Name of the property.</param>
             <param name="propertyType">Type of the property.</param>
-            <param name="isArray">if set to <c>true</c> [is array].</param>
-            <param name="propertyTypeName">Name of the property type.</param>
-            <param name="isPrimitiveType">if set to <c>true</c> [is primitive type].</param>
+            <param name="collectionInnerTypes">The collection inner types.</param>
+            <param name="transformablePropertyType">Type of the transformable property.</param>
             <param name="hasDefaultValue">if set to <c>true</c> [has default value].</param>
             <param name="defaultValue">The default value.</param>
         </member>
@@ -167,28 +280,21 @@
             The type of the property.
             </value>
         </member>
-        <member name="P:Castle.Sharp2Js.PropertyBag.IsArray">
+        <member name="P:Castle.Sharp2Js.PropertyBag.TransformablePropertyType">
             <summary>
-            Gets or sets a value indicating whether this instance is an array.
+            Determines what class of object the transformer treats the object as 
+            which determines how the pieces are treated when writing Js objects.
             </summary>
             <value>
-              <c>true</c> if this instance is an array; otherwise, <c>false</c>.
+            The type of the transformable property.
             </value>
         </member>
-        <member name="P:Castle.Sharp2Js.PropertyBag.PropertyTypeName">
+        <member name="P:Castle.Sharp2Js.PropertyBag.CollectionInnerTypes">
             <summary>
             Gets or sets the name of the property type.
             </summary>
             <value>
             The name of the property type.
-            </value>
-        </member>
-        <member name="P:Castle.Sharp2Js.PropertyBag.IsPrimitiveType">
-            <summary>
-            Gets or sets a value indicating whether this instance is primitive type.
-            </summary>
-            <value>
-            <c>true</c> if this instance is primitive type; otherwise, <c>false</c>.
             </value>
         </member>
         <member name="P:Castle.Sharp2Js.PropertyBag.HasDefaultValue">
@@ -205,6 +311,76 @@
             </summary>
             <value>
             The default value.
+            </value>
+        </member>
+        <member name="P:Castle.Sharp2Js.PropertyBag.TypeDefinition">
+            <summary>
+            Gets or sets the type definition.
+            </summary>
+            <value>
+            The type definition.
+            </value>
+        </member>
+        <member name="T:Castle.Sharp2Js.PropertyBag.TransformablePropertyTypeEnum">
+            <summary>
+            Transformable property types understood by sharp2Js
+            </summary>
+        </member>
+        <member name="F:Castle.Sharp2Js.PropertyBag.TransformablePropertyTypeEnum.Primitive">
+            <summary>
+            The primitive
+            </summary>
+        </member>
+        <member name="F:Castle.Sharp2Js.PropertyBag.TransformablePropertyTypeEnum.CollectionType">
+            <summary>
+            The collection type
+            </summary>
+        </member>
+        <member name="F:Castle.Sharp2Js.PropertyBag.TransformablePropertyTypeEnum.DictionaryType">
+            <summary>
+            The dictionary type
+            </summary>
+        </member>
+        <member name="F:Castle.Sharp2Js.PropertyBag.TransformablePropertyTypeEnum.ReferenceType">
+            <summary>
+            The reference type
+            </summary>
+        </member>
+        <member name="T:Castle.Sharp2Js.PropertyBagTypeInfo">
+            <summary>
+            Contains types contained within collections and designations for dictionary types
+            </summary>
+        </member>
+        <member name="P:Castle.Sharp2Js.PropertyBagTypeInfo.Type">
+            <summary>
+            Gets or sets the type.
+            </summary>
+            <value>
+            The type.
+            </value>
+        </member>
+        <member name="P:Castle.Sharp2Js.PropertyBagTypeInfo.IsDictionaryKey">
+            <summary>
+            Gets or sets a value indicating whether this instance is the dictionary key.
+            </summary>
+            <value>
+            <c>true</c> if this instance is the dictionary key; otherwise, <c>false</c>.
+            </value>
+        </member>
+        <member name="P:Castle.Sharp2Js.PropertyBagTypeInfo.IsPrimitiveType">
+            <summary>
+            Gets or sets a value indicating whether this instance is primitive type.
+            </summary>
+            <value>
+            <c>true</c> if this instance is primitive type; otherwise, <c>false</c>.
+            </value>
+        </member>
+        <member name="P:Castle.Sharp2Js.PropertyBagTypeInfo.IsEnumType">
+            <summary>
+            Gets or sets a value indicating whether this instance is enum type.
+            </summary>
+            <value>
+            <c>true</c> if this instance is enum type; otherwise, <c>false</c>.
             </value>
         </member>
         <member name="T:Castle.Sharp2Js.SampleData.AddressInformation">
@@ -309,6 +485,27 @@
             <value>
             The value.
             </value>
+        </member>
+        <member name="T:Castle.Sharp2Js.TypePropertyDictionaryGenerator">
+            <summary>
+            Generates a list of property type information to be used by the Js Generator
+            </summary>
+        </member>
+        <member name="M:Castle.Sharp2Js.TypePropertyDictionaryGenerator.GetPropertyDictionaryForTypeGeneration(System.Collections.Generic.IEnumerable{System.Type},Castle.Sharp2Js.JsGeneratorOptions,System.Collections.Generic.List{Castle.Sharp2Js.PropertyBag})">
+            <summary>
+            Gets the property dictionary to be used for type generation.
+            </summary>
+            <param name="types">The types to generate property information for.</param>
+            <param name="generatorOptions">The generator options.</param>
+            <param name="propertyTypeCollection">The output collection of properties discovered through reflection of the supplied classes.</param>
+            <returns></returns>
+        </member>
+        <member name="M:Castle.Sharp2Js.TypePropertyDictionaryGenerator.GetCollectionInnerTypes(System.Type)">
+            <summary>
+            Gets inner types of collections and dictionaries.
+            </summary>
+            <param name="propertyType">Type of the property.</param>
+            <returns></returns>
         </member>
     </members>
 </doc>

--- a/Castle.Sharp2Js.Tests/Castle.Sharp2Js.Tests.csproj
+++ b/Castle.Sharp2Js.Tests/Castle.Sharp2Js.Tests.csproj
@@ -46,6 +46,10 @@
       <HintPath>..\packages\Jint.2.6.0\lib\portable-net40+sl50+win+WindowsPhoneApp81+wp80\Jint.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>

--- a/Castle.Sharp2Js.Tests/Castle.Sharp2Js.Tests.csproj
+++ b/Castle.Sharp2Js.Tests/Castle.Sharp2Js.Tests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Castle.Sharp2Js.Tests</RootNamespace>
     <AssemblyName>Castle.Sharp2Js.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -26,6 +26,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -34,14 +35,23 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Jil, Version=2.12.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Jil.2.12.1\lib\net45\Jil.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Jint, Version=2.6.0.0, Culture=neutral, PublicKeyToken=2e92ba9c8d81157f, processorArchitecture=MSIL">
       <HintPath>..\packages\Jint.2.6.0\lib\portable-net40+sl50+win+WindowsPhoneApp81+wp80\Jint.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Sigil, Version=4.5.0.0, Culture=neutral, PublicKeyToken=2d06c3494341c8ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sigil.4.5.0\lib\net45\Sigil.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -60,6 +70,7 @@
     <Compile Include="DTOs\SampleModel.cs" />
     <Compile Include="JsGeneratorTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SerializerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Castle.Sharp2Js\Castle.Sharp2Js.csproj">

--- a/Castle.Sharp2Js.Tests/DTOs/SampleModel.cs
+++ b/Castle.Sharp2Js.Tests/DTOs/SampleModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
@@ -50,5 +51,112 @@ namespace Castle.Sharp2Js.Tests.DTOs
         public string alreadyUnderscored { get; set; }
         public string RegularCased { get; set; }
     }
+    [ExcludeFromCodeCoverage]
+    public class CustomListTest<T> : IList
+    {
+        private List<T> _privateList = new List<T>();
+        public IEnumerator GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void CopyTo(Array array, int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int Count
+        {
+            get { return _privateList.Count; }
+        }
+
+        public object SyncRoot
+        {
+            get { return _privateList; }
+        }
+
+        public bool IsSynchronized
+        {
+            get { return true; }
+        }
+
+        public int Add(object value)
+        {
+            _privateList.Add((T)value);
+            return _privateList.Count;
+        }
+
+        public bool Contains(object value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Clear()
+        {
+            throw new NotImplementedException();
+        }
+
+        public int IndexOf(object value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Insert(int index, object value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Remove(object value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object this[int index]
+        {
+            get { return _privateList[index]; }
+            set { throw new NotImplementedException(); }
+        }
+
+        public bool IsReadOnly
+        {
+            get { return false; }
+        }
+
+        public bool IsFixedSize
+        {
+            get { return false; }
+        }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class CollectionTesting
+    {
+        public List<string> ListCollection { get; set; }
+
+        public CollectionTesting[] ObjectArrayCollection { get; set; }
+
+        public ArrayList ArrayListCollection { get; set; }
+
+        public Dictionary<string, string> DictionaryCollection { get; set; }
+
+        public Dictionary<string, ArrayTypeTest> DictionaryObjectCollection { get; set; }
+
+        public CustomListTest<string> CustomListCollection { get; set; }
+
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class DictionaryKeyTesting
+    {
+        public Dictionary<ArrayTypeTest, string> DictionaryObjectKeyCollection { get; set; }
+
+    }
+
+
 
 }

--- a/Castle.Sharp2Js.Tests/DTOs/SampleModel.cs
+++ b/Castle.Sharp2Js.Tests/DTOs/SampleModel.cs
@@ -157,6 +157,23 @@ namespace Castle.Sharp2Js.Tests.DTOs
 
     }
 
+    [ExcludeFromCodeCoverage]
+    public class EnumTesting
+    {
+        public EnumTest1 EnumTest1 { get; set; }
+        public EnumTest2 EnumTest2 { get; set; }
+    }
 
+    public enum EnumTest1
+    {
+        EnumVal1,
+        EnumVal2
+    }
+
+    public enum EnumTest2
+    {
+        EnumVal1 = 1,
+        EnumVal2 = 2
+    }
 
 }

--- a/Castle.Sharp2Js.Tests/JsGeneratorTests.cs
+++ b/Castle.Sharp2Js.Tests/JsGeneratorTests.cs
@@ -470,6 +470,72 @@ namespace Castle.Sharp2Js.Tests
 
         }
 
+        [Test]
+        public void EnumHandling()
+        {
+            //Generate a basic javascript model from a C# class
+
+            var modelType = typeof(EnumTesting);
+
+            var js = new Jint.Parser.JavaScriptParser();
+
+            var outputJs = JsGenerator.Generate(new[] { modelType }, new JsGeneratorOptions()
+            {
+                ClassNameConstantsToRemove = new List<string>() { "Dto" },
+                CamelCase = true,
+                IncludeMergeFunction = true,
+                OutputNamespace = "models",
+                RespectDataMemberAttribute = true,
+                RespectDefaultValueAttribute = true,
+                
+            });
+
+
+
+            Assert.IsTrue(!string.IsNullOrEmpty(outputJs));
+
+            try
+            {
+                js.Parse(outputJs);
+
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected no exception parsing javascript, but got: " + ex.Message);
+            }
+
+            outputJs = JsGenerator.Generate(new[] { modelType }, new JsGeneratorOptions()
+            {
+                ClassNameConstantsToRemove = new List<string>() { "Dto" },
+                CamelCase = true,
+                IncludeMergeFunction = true,
+                OutputNamespace = "models",
+                RespectDataMemberAttribute = true,
+                RespectDefaultValueAttribute = true,
+                TreatEnumsAsStrings = true
+            });
+
+
+
+            Assert.IsTrue(!string.IsNullOrEmpty(outputJs));
+
+
+            
+
+
+
+            try
+            {
+                js.Parse(outputJs);
+
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected no exception parsing javascript, but got: " + ex.Message);
+            }
+
+        }
+
     }
 
     

--- a/Castle.Sharp2Js.Tests/JsGeneratorTests.cs
+++ b/Castle.Sharp2Js.Tests/JsGeneratorTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Text;
 using Castle.Sharp2Js.SampleData;
 using Castle.Sharp2Js.Tests.DTOs;
 using Jint.Parser.Ast;
@@ -407,6 +408,55 @@ namespace Castle.Sharp2Js.Tests
             var js = new Jint.Parser.JavaScriptParser();
 
             
+
+            try
+            {
+                js.Parse(outputJs);
+
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected no exception parsing javascript, but got: " + ex.Message);
+            }
+
+        }
+
+        [Test]
+        public void CustomFunctionHandling()
+        {
+            //Generate a basic javascript model from a C# class
+
+            var modelType = typeof(CollectionTesting);
+
+            var outputJs = JsGenerator.Generate(new[] {modelType}, new JsGeneratorOptions()
+            {
+                ClassNameConstantsToRemove = new List<string>() {"Dto"},
+                CamelCase = true,
+                IncludeMergeFunction = true,
+                OutputNamespace = "models",
+                RespectDataMemberAttribute = true,
+                RespectDefaultValueAttribute = true,
+                CustomFunctionProcessors =
+                    new List<Action<StringBuilder, IEnumerable<PropertyBag>, JsGeneratorOptions>>()
+                    {
+                        (builder, bags, arg3) =>
+                        {
+                            builder.AppendLine($"\tthis.helloWorld = function () {{");
+                            builder.AppendLine("\t\tconsole.log('hello');");
+                            builder.AppendLine("\t}");
+                        }
+                    }
+            });
+
+            
+
+            Assert.IsTrue(!string.IsNullOrEmpty(outputJs));
+
+            Assert.IsTrue(outputJs.Contains("this.helloWorld"));
+
+            var js = new Jint.Parser.JavaScriptParser();
+
+
 
             try
             {

--- a/Castle.Sharp2Js.Tests/JsGeneratorTests.cs
+++ b/Castle.Sharp2Js.Tests/JsGeneratorTests.cs
@@ -348,6 +348,78 @@ namespace Castle.Sharp2Js.Tests
 
         }
 
+
+        [Test]
+        public void InvalidDictionaryKeyHandling()
+        {
+            //Generate a basic javascript model from a C# class
+
+            var modelType = typeof(DictionaryKeyTesting);
+
+
+            var codeRanThrough = false;
+            try
+            {
+                JsGenerator.Generate(new[] { modelType }, new JsGeneratorOptions()
+                {
+                    ClassNameConstantsToRemove = null,
+                    CamelCase = true,
+                    IncludeMergeFunction = false,
+                    OutputNamespace = "models",
+                    RespectDataMemberAttribute = false,
+                    RespectDefaultValueAttribute = false
+                });
+
+                codeRanThrough = true;
+
+            }
+            catch (Exception)
+            {
+                Assert.Pass();
+            }
+
+            if (codeRanThrough)
+            {
+                Assert.Fail("Expected exception generating type with incompatible dictionary key type.");
+            }
+
+        }
+
+        [Test]
+        public void CollectionHandling()
+        {
+            //Generate a basic javascript model from a C# class
+
+            var modelType = typeof(CollectionTesting);
+
+            var outputJs = JsGenerator.Generate(new[] { modelType }, new JsGeneratorOptions()
+            {
+                ClassNameConstantsToRemove = new List<string>() { "Dto" },
+                CamelCase = true,
+                IncludeMergeFunction = true,
+                OutputNamespace = "models",
+                RespectDataMemberAttribute = true,
+                RespectDefaultValueAttribute = true
+            });
+
+            Assert.IsTrue(!string.IsNullOrEmpty(outputJs));
+
+            var js = new Jint.Parser.JavaScriptParser();
+
+            
+
+            try
+            {
+                js.Parse(outputJs);
+
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected no exception parsing javascript, but got: " + ex.Message);
+            }
+
+        }
+
     }
 
     

--- a/Castle.Sharp2Js.Tests/SerializerTests.cs
+++ b/Castle.Sharp2Js.Tests/SerializerTests.cs
@@ -31,5 +31,33 @@ namespace Castle.Sharp2Js.Tests
 
             string res = Jil.JSON.Serialize(collectionObj);
         }
+
+        [Test]
+        public void TestJilEnumSerialization()
+        {
+            var collectionObj = new EnumTesting()
+            {
+                EnumTest1 = EnumTest1.EnumVal1,
+                EnumTest2 = EnumTest2.EnumVal2
+            };
+
+            
+
+            string res = Jil.JSON.Serialize(collectionObj);
+        }
+
+        [Test]
+        public void TestNewtonSoftEnumSerialization()
+        {
+            var collectionObj = new EnumTesting()
+            {
+                EnumTest1 = EnumTest1.EnumVal2,
+                EnumTest2 = EnumTest2.EnumVal2
+            };
+
+            
+
+            string res = Newtonsoft.Json.JsonConvert.SerializeObject(collectionObj);
+        }
     }
 }

--- a/Castle.Sharp2Js.Tests/SerializerTests.cs
+++ b/Castle.Sharp2Js.Tests/SerializerTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using Castle.Sharp2Js.Tests.DTOs;
+using NUnit.Framework;
+using NUnit.Framework.Constraints;
+
+namespace Castle.Sharp2Js.Tests
+{
+    [ExcludeFromCodeCoverage]
+    [TestFixture]
+    public class SerializerTests
+    {
+        [Test]
+        public void TestJilCollectionSerialization()
+        {
+            var collectionObj = new CollectionTesting()
+            {
+                ArrayListCollection = new ArrayList() {"Object1", "Object2"},
+                CustomListCollection = new CustomListTest<string>() {"Item1", "Item2"},
+                DictionaryCollection = new Dictionary<string, string>() {},
+                ListCollection = new List<string>() { "Item 1", "Item 2" },
+                ObjectArrayCollection = new [] { new CollectionTesting() }
+            };
+
+            collectionObj.DictionaryCollection.Add("Key 1", "Value 1");
+            collectionObj.DictionaryCollection.Add("Key 2", "Value 2");
+
+            string res = Jil.JSON.Serialize(collectionObj);
+        }
+    }
+}

--- a/Castle.Sharp2Js.Tests/packages.config
+++ b/Castle.Sharp2Js.Tests/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Jil" version="2.12.1" targetFramework="net45" />
   <package id="Jint" version="2.6.0" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net4" />
   <package id="Sigil" version="4.5.0" targetFramework="net45" />
 </packages>

--- a/Castle.Sharp2Js.Tests/packages.config
+++ b/Castle.Sharp2Js.Tests/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Jil" version="2.12.1" targetFramework="net45" />
   <package id="Jint" version="2.6.0" targetFramework="net452" />
   <package id="NUnit" version="2.6.4" targetFramework="net4" />
+  <package id="Sigil" version="4.5.0" targetFramework="net45" />
 </packages>

--- a/Castle.Sharp2Js/Castle.Sharp2Js.csproj
+++ b/Castle.Sharp2Js/Castle.Sharp2Js.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Castle.Sharp2Js</RootNamespace>
     <AssemblyName>Castle.Sharp2Js</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -23,6 +23,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Castle.Sharp2Js.xml</DocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,6 +33,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Castle.Sharp2Js.xml</DocumentationFile>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Castle.Sharp2Js/Castle.Sharp2Js.csproj
+++ b/Castle.Sharp2Js/Castle.Sharp2Js.csproj
@@ -46,11 +46,13 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Helpers.cs" />
     <Compile Include="JsGenerator.cs" />
     <Compile Include="JsGeneratorOptions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PropertyBag.cs" />
     <Compile Include="SampleData\SampleModel.cs" />
+    <Compile Include="TypePropertyDictionaryGenerator.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Castle.Sharp2Js/Helpers.cs
+++ b/Castle.Sharp2Js/Helpers.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+
+namespace Castle.Sharp2Js
+{
+    /// <summary>
+    /// Helper functions for Js Generator
+    /// </summary>
+    public static class Helpers
+    {
+        /// <summary>
+        /// Gets the name, filtering out the strings provided.
+        /// </summary>
+        /// <param name="input">The input.</param>
+        /// <param name="nameFilters">The name filters.</param>
+        /// <returns></returns>
+        public static string GetName(string input, List<string> nameFilters)
+        {
+            return nameFilters == null
+                ? input
+                : nameFilters.Aggregate(input, (current, nameFilter) => current.Replace(nameFilter, string.Empty));
+        }
+
+        /// <summary>
+        /// Camel cases an input string.
+        /// </summary>
+        /// <param name="input">The string.</param>
+        /// <param name="camelCase">if set to <c>true</c> [camel case].</param>
+        /// <returns></returns>
+        public static string ToCamelCase(string input, bool camelCase)
+        {
+            if (!camelCase) return input;
+
+            var s = input;
+            if (!char.IsUpper(s[0])) return s;
+
+            var cArr = s.ToCharArray();
+            for (var i = 0; i < cArr.Length; i++)
+            {
+                if (i > 0 && i + 1 < cArr.Length && !char.IsUpper(cArr[i + 1])) break;
+                cArr[i] = char.ToLowerInvariant(cArr[i]);
+            }
+            return new string(cArr);
+        }
+
+        /// <summary>
+        /// Determines whether the specified property type is a collection.
+        /// </summary>
+        /// <param name="propertyType">Type of the property.</param>
+        /// <returns></returns>
+        public static bool IsCollectionType(Type propertyType)
+        {
+
+            return (propertyType.GetInterfaces().Contains(typeof(IList)) ||
+                    propertyType.GetInterfaces().Contains(typeof(ICollection)) ||
+                    propertyType.GetInterfaces().Contains(typeof(IDictionary)) ||
+                    propertyType.IsArray);
+        }
+
+        /// <summary>
+        /// Determines whether the specified property type is a dictionary.
+        /// </summary>
+        /// <param name="propertyType">Type of the property.</param>
+        /// <returns></returns>
+        public static bool IsDictionaryType(Type propertyType)
+        {
+            return (propertyType.GetInterfaces().Contains(typeof(IDictionary)));
+        }
+
+        /// <summary>
+        /// Determines whether the specified property type is primitive.
+        /// </summary>
+        /// <param name="propertyType">Type of the property.</param>
+        /// <returns></returns>
+        public static bool IsPrimitive(Type propertyType)
+        {
+            return propertyType.IsPrimitive || propertyType.IsValueType ||
+                   propertyType == typeof(string);
+        }
+
+        /// <summary>
+        /// Determines whether the property should be generated in the Js model.
+        /// </summary>
+        /// <param name="propertyInfo">The property information.</param>
+        /// <param name="generatorOptions">The generator options.</param>
+        /// <returns></returns>
+        public static bool ShouldGenerateMember(PropertyInfo propertyInfo, JsGeneratorOptions generatorOptions)
+        {
+            if (!generatorOptions.RespectDataMemberAttribute) return true;
+
+            var customAttributes = propertyInfo.GetCustomAttributes(true);
+
+            return customAttributes.All(p => (p as IgnoreDataMemberAttribute) == null);
+        }
+
+        /// <summary>
+        /// Determines whether the property has a default value specified by the DefaultValue attribute.
+        /// </summary>
+        /// <param name="propertyInfo">The property information.</param>
+        /// <param name="generatorOptions">The generator options.</param>
+        /// <returns></returns>
+        public static bool HasDefaultValue(PropertyInfo propertyInfo, JsGeneratorOptions generatorOptions)
+        {
+            if (!generatorOptions.RespectDefaultValueAttribute) return false;
+
+            var customAttributes = propertyInfo.GetCustomAttributes(true);
+
+            if (customAttributes.All(p => (p as DefaultValueAttribute) == null)) return false;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Reads the default value from the attribute.
+        /// </summary>
+        /// <param name="propertyInfo">The property information.</param>
+        /// <returns></returns>
+        public static object ReadDefaultValueFromAttribute(PropertyInfo propertyInfo)
+        {
+            var customAttributes = propertyInfo.GetCustomAttributes(true);
+
+            var defaultValueAttribute = (DefaultValueAttribute)customAttributes.First(p => (p as DefaultValueAttribute) != null);
+
+            return defaultValueAttribute.Value;
+        }
+
+        /// <summary>
+        /// Gets the name of the property.
+        /// </summary>
+        /// <param name="propertyInfo">The property information.</param>
+        /// <param name="generatorOptions">The generator options.</param>
+        /// <returns></returns>
+        public static string GetPropertyName(PropertyInfo propertyInfo, JsGeneratorOptions generatorOptions)
+        {
+            if (!generatorOptions.RespectDataMemberAttribute) return propertyInfo.Name;
+
+            var customAttributes = propertyInfo.GetCustomAttributes(true);
+
+            if (customAttributes.All(p => (p as DataMemberAttribute) == null)) return propertyInfo.Name;
+
+            var dataMemberAttribute = (DataMemberAttribute)customAttributes.First(p => (p as DataMemberAttribute) != null);
+
+            return !string.IsNullOrWhiteSpace(dataMemberAttribute.Name) ? dataMemberAttribute.Name : propertyInfo.Name;
+        }
+    }
+}

--- a/Castle.Sharp2Js/JsGenerator.cs
+++ b/Castle.Sharp2Js/JsGenerator.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
-using System.Reflection;
-using System.Runtime.Serialization;
 using System.Text;
 
 namespace Castle.Sharp2Js
@@ -42,7 +38,7 @@ namespace Castle.Sharp2Js
             {
                 throw new ArgumentNullException(nameof(passedOptions), "Options cannot be null.");
             }
-            var propertyClassCollection = GetPropertyDictionaryForTypeGeneration(typesToGenerate, passedOptions);
+            var propertyClassCollection = TypePropertyDictionaryGenerator.GetPropertyDictionaryForTypeGeneration(typesToGenerate, passedOptions);
             var js = GenerateJs(propertyClassCollection, passedOptions);
             return js;
         }
@@ -58,7 +54,7 @@ namespace Castle.Sharp2Js
         [Obsolete("This is a legacy method. Please use the Generate(...) method instead.")]
         public static string GenerateJsModelFromTypeWithDescendants(Type modelType, bool camelCasePropertyNames, string outputNamespace)
         {
-            var propertyDictionary = GetPropertyDictionaryForTypeGeneration(new[] { modelType }, Options);
+            var propertyDictionary = TypePropertyDictionaryGenerator.GetPropertyDictionaryForTypeGeneration(new[] { modelType }, Options);
 
             return GenerateJs(propertyDictionary, new JsGeneratorOptions()
             {
@@ -170,19 +166,19 @@ namespace Castle.Sharp2Js
                         p.TransformablePropertyType == PropertyBag.TransformablePropertyTypeEnum.ReferenceType))
             {
                 sb.AppendLine(
-                    $"{options.OutputNamespace}.{GetName(type.First().TypeName, options.ClassNameConstantsToRemove)} = function (cons, overrideObj) {{");
+                    $"{options.OutputNamespace}.{Helpers.GetName(type.First().TypeName, options.ClassNameConstantsToRemove)} = function (cons, overrideObj) {{");
                 sb.AppendLine("\tif (!overrideObj) { overrideObj = { }; }");
                 sb.AppendLine("\tif (!cons) { cons = { }; }");
             }
             else if (type.First().TypeDefinition.IsEnum)
             {
                 sb.AppendLine(
-                    $"{options.OutputNamespace}.{GetName(type.First().TypeName, options.ClassNameConstantsToRemove)} = {{");
+                    $"{options.OutputNamespace}.{Helpers.GetName(type.First().TypeName, options.ClassNameConstantsToRemove)} = {{");
             }
             else
             {
                 sb.AppendLine(
-                    $"{options.OutputNamespace}.{GetName(type.First().TypeName, options.ClassNameConstantsToRemove)} = function (cons) {{");
+                    $"{options.OutputNamespace}.{Helpers.GetName(type.First().TypeName, options.ClassNameConstantsToRemove)} = function (cons) {{");
 
                 sb.AppendLine("\tif (!cons) { cons = { }; }");
             }
@@ -207,67 +203,65 @@ namespace Castle.Sharp2Js
                 {
                     case PropertyBag.TransformablePropertyTypeEnum.CollectionType:
                         sb.AppendLine(
-                            $"\t\tif (!mergeObj.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}) {{");
-                        sb.AppendLine($"\t\t\tthis.{ToCamelCase(propEntry.PropertyName, options.CamelCase)} = [];");
+                            $"\t\tif (!mergeObj.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}) {{");
+                        sb.AppendLine($"\t\t\tthis.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)} = [];");
                         sb.AppendLine("\t\t}");
                         sb.AppendLine(
-                            $"\t\tif (this.{ToCamelCase(propEntry.PropertyName, options.CamelCase)} != null) {{");
-                        sb.AppendLine(string.Format("\t\t\tthis.{0}.splice(0, this.{0}.length);",
-                            ToCamelCase(propEntry.PropertyName, options.CamelCase)));
+                            $"\t\tif (this.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)} != null) {{");
+                        sb.AppendLine(string.Format("\t\t\tthis.{0}.splice(0, this.{0}.length);", Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)));
                         sb.AppendLine("\t\t}");
                         sb.AppendLine(
-                            $"\t\tif (mergeObj.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}) {{");
+                            $"\t\tif (mergeObj.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}) {{");
                         sb.AppendLine(
-                            $"\t\t\tif (this.{ToCamelCase(propEntry.PropertyName, options.CamelCase)} === null) {{");
-                        sb.AppendLine($"\t\t\t\tthis.{ToCamelCase(propEntry.PropertyName, options.CamelCase)} = [];");
+                            $"\t\t\tif (this.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)} === null) {{");
+                        sb.AppendLine($"\t\t\t\tthis.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)} = [];");
                         sb.AppendLine("\t\t\t}");
                         sb.AppendLine(
-                            $"\t\t\tfor (i = 0; i < mergeObj.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}.length; i++) {{");
-                        sb.AppendLine(string.Format("\t\t\t\tthis.{0}.push(mergeObj.{0}[i]);",
-                            ToCamelCase(propEntry.PropertyName, options.CamelCase)));
+                            $"\t\t\tfor (i = 0; i < mergeObj.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}.length; i++) {{");
+                        sb.AppendLine(string.Format("\t\t\t\tthis.{0}.push(mergeObj.{0}[i]);", Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)));
                         sb.AppendLine("\t\t\t}");
                         sb.AppendLine("\t\t}");
                         break;
                     case PropertyBag.TransformablePropertyTypeEnum.DictionaryType:
                         sb.AppendLine(
-                            $"\t\tif (this.{ToCamelCase(propEntry.PropertyName, options.CamelCase)} != null) {{");
+                            $"\t\tif (this.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)} != null) {{");
                         sb.AppendLine(
-                            $"\t\t\tfor (var key in this.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}) {{");
+                            $"\t\t\tfor (var key in this.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}) {{");
                         sb.AppendLine(
-                            $"\t\t\t\tif (this.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}.hasOwnProperty(key)) {{");
+                            $"\t\t\t\tif (this.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}.hasOwnProperty(key)) {{");
                         sb.AppendLine(
-                            $"\t\t\t\t\tdelete this.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}[key];");
+                            $"\t\t\t\t\tdelete this.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}[key];");
                         sb.AppendLine("\t\t\t\t}");
                         sb.AppendLine("\t\t\t}");
                         sb.AppendLine("\t\t}");
                         sb.AppendLine(
-                            $"\t\tif (mergeObj.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}) {{");
+                            $"\t\tif (mergeObj.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}) {{");
                         sb.AppendLine(
-                            $"\t\t\tfor (var key in mergeObj.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}) {{");
+                            $"\t\t\tfor (var key in mergeObj.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}) {{");
                         sb.AppendLine(
-                            $"\t\t\t\tif (mergeObj.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}.hasOwnProperty(key)) {{");
+                            $"\t\t\t\tif (mergeObj.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}.hasOwnProperty(key)) {{");
                         sb.AppendLine(
-                            $"\t\t\t\t\tthis.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}[key] = mergeObj.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}[key];");
+                            $"\t\t\t\t\tthis.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}[key] = mergeObj.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}[key];");
                         sb.AppendLine("\t\t\t\t}");
                         sb.AppendLine("\t\t\t}");
                         sb.AppendLine("\t\t}");
                         break;
                     case PropertyBag.TransformablePropertyTypeEnum.ReferenceType:
                         sb.AppendLine(
-                            $"\t\tif (mergeObj.{ToCamelCase(propEntry.PropertyName, options.CamelCase)} == null) {{");
-                        sb.AppendLine($"\t\t\tthis.{ToCamelCase(propEntry.PropertyName, options.CamelCase)} = null;");
+                            $"\t\tif (mergeObj.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)} == null) {{");
+                        sb.AppendLine($"\t\t\tthis.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)} = null;");
                         sb.AppendLine(
-                            $"\t\t}} else if (this.{ToCamelCase(propEntry.PropertyName, options.CamelCase)} != null) {{");
+                            $"\t\t}} else if (this.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)} != null) {{");
                         sb.AppendLine(
-                            $"\t\t\tthis.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}.$merge(mergeObj.{ToCamelCase(propEntry.PropertyName, options.CamelCase)});");
+                            $"\t\t\tthis.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}.$merge(mergeObj.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)});");
                         sb.AppendLine("\t\t} else {");
                         sb.AppendLine(
-                            $"\t\t\tthis.{ToCamelCase(propEntry.PropertyName, options.CamelCase)} = mergeObj.{ToCamelCase(propEntry.PropertyName, options.CamelCase)};");
+                            $"\t\t\tthis.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)} = mergeObj.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)};");
                         sb.AppendLine("\t\t}");
                         break;
                     case PropertyBag.TransformablePropertyTypeEnum.Primitive:
                         sb.AppendLine(
-                            $"\t\tthis.{ToCamelCase(propEntry.PropertyName, options.CamelCase)} = mergeObj.{ToCamelCase(propEntry.PropertyName, options.CamelCase)};");
+                            $"\t\tthis.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)} = mergeObj.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)};");
                         break;
                 }
             }
@@ -286,26 +280,26 @@ namespace Castle.Sharp2Js
             {
                 sb.AppendLine(
                     propEntry.PropertyType == typeof(string)
-                        ? $"\t{ToCamelCase(propEntry.PropertyName, options.CamelCase)}: '{propEntry.DefaultValue}',"
-                        : $"\t{ToCamelCase(propEntry.PropertyName, options.CamelCase)}: {propEntry.DefaultValue},");
+                        ? $"\t{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}: '{propEntry.DefaultValue}',"
+                        : $"\t{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}: {propEntry.DefaultValue},");
             }
             else if (propEntry.HasDefaultValue)
             {
                 sb.AppendLine(
-                    $"\tif (!cons.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}) {{");
+                    $"\tif (!cons.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}) {{");
                 sb.AppendLine(
                     propEntry.PropertyType == typeof(string)
-                        ? $"\t\tthis.{ToCamelCase(propEntry.PropertyName, options.CamelCase)} = '{propEntry.DefaultValue}';"
-                        : $"\t\tthis.{ToCamelCase(propEntry.PropertyName, options.CamelCase)} = {propEntry.DefaultValue};");
+                        ? $"\t\tthis.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)} = '{propEntry.DefaultValue}';"
+                        : $"\t\tthis.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)} = {propEntry.DefaultValue};");
                 sb.AppendLine("\t} else {");
                 sb.AppendLine(
-                    $"\t\tthis.{ToCamelCase(propEntry.PropertyName, options.CamelCase)} = cons.{ToCamelCase(propEntry.PropertyName, options.CamelCase)};");
+                    $"\t\tthis.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)} = cons.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)};");
                 sb.AppendLine("\t}");
             }
             else
             {
                 sb.AppendLine(
-                    $"\tthis.{ToCamelCase(propEntry.PropertyName, options.CamelCase)} = cons.{ToCamelCase(propEntry.PropertyName, options.CamelCase)};");
+                    $"\tthis.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)} = cons.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)};");
             }
         }
 
@@ -318,15 +312,15 @@ namespace Castle.Sharp2Js
         private static void BuildObjectProperty(StringBuilder sb, PropertyBag propEntry, JsGeneratorOptions options)
         {
 
-            sb.AppendLine($"\tthis.{ToCamelCase(propEntry.PropertyName, options.CamelCase)} = null;");
-            sb.AppendLine($"\tif (cons.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}) {{");
+            sb.AppendLine($"\tthis.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)} = null;");
+            sb.AppendLine($"\tif (cons.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}) {{");
             sb.AppendLine(
-                $"\t\tif (!overrideObj.{GetName(propEntry.PropertyType.Name, options.ClassNameConstantsToRemove)}) {{");
+                $"\t\tif (!overrideObj.{Helpers.GetName(propEntry.PropertyType.Name, options.ClassNameConstantsToRemove)}) {{");
             sb.AppendLine(
-                $"\t\t\tthis.{ToCamelCase(propEntry.PropertyName, options.CamelCase)} = new {options.OutputNamespace}.{GetName(propEntry.PropertyType.Name, options.ClassNameConstantsToRemove)}(cons.{ToCamelCase(propEntry.PropertyName, options.CamelCase)});");
+                $"\t\t\tthis.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)} = new {options.OutputNamespace}.{Helpers.GetName(propEntry.PropertyType.Name, options.ClassNameConstantsToRemove)}(cons.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)});");
             sb.AppendLine("\t\t} else {");
             sb.AppendLine(
-                $"\t\t\tthis.{ToCamelCase(propEntry.PropertyName, options.CamelCase)} = new overrideObj.{GetName(propEntry.PropertyType.Name, options.ClassNameConstantsToRemove)}(cons.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}, overrideObj);");
+                $"\t\t\tthis.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)} = new overrideObj.{Helpers.GetName(propEntry.PropertyType.Name, options.ClassNameConstantsToRemove)}(cons.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}, overrideObj);");
 
             sb.AppendLine("\t\t}");
             sb.AppendLine("\t}");
@@ -340,31 +334,29 @@ namespace Castle.Sharp2Js
         /// <param name="options">The options.</param>
         private static void BuildArrayProperty(StringBuilder sb, PropertyBag propEntry, JsGeneratorOptions options)
         {
-            sb.AppendLine(string.Format("\tthis.{0} = new Array(cons.{0} == null ? 0 : cons.{1}.length );",
-                ToCamelCase(propEntry.PropertyName, options.CamelCase),
-                ToCamelCase(propEntry.PropertyName, options.CamelCase)));
-            sb.AppendLine($"\tif(cons.{ToCamelCase(propEntry.PropertyName, options.CamelCase)} != null) {{");
+            sb.AppendLine(string.Format("\tthis.{0} = new Array(cons.{0} == null ? 0 : cons.{1}.length );", Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase), Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)));
+            sb.AppendLine($"\tif(cons.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)} != null) {{");
             sb.AppendLine(
-                $"\t\tfor (i = 0, length = cons.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}.length; i < length; i++) {{");
+                $"\t\tfor (i = 0, length = cons.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}.length; i < length; i++) {{");
 
             var collectionType = propEntry.CollectionInnerTypes.First();
 
             if (!collectionType.IsPrimitiveType)
             {
                 sb.AppendLine(
-                    $"\t\t\tif (!overrideObj.{GetName(collectionType.Type.Name, options.ClassNameConstantsToRemove)}) {{");
+                    $"\t\t\tif (!overrideObj.{Helpers.GetName(collectionType.Type.Name, options.ClassNameConstantsToRemove)}) {{");
                 sb.AppendLine(
-                    $"\t\t\t\tthis.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}[i] = new {options.OutputNamespace}.{GetName(collectionType.Type.Name, options.ClassNameConstantsToRemove)}(cons.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}[i]);");
+                    $"\t\t\t\tthis.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}[i] = new {options.OutputNamespace}.{Helpers.GetName(collectionType.Type.Name, options.ClassNameConstantsToRemove)}(cons.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}[i]);");
                 sb.AppendLine("\t\t\t} else {");
                 sb.AppendLine(
-                    $"\t\t\t\tthis.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}[i] = new overrideObj.{GetName(collectionType.Type.Name, options.ClassNameConstantsToRemove)}(cons.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}[i], overrideObj);");
+                    $"\t\t\t\tthis.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}[i] = new overrideObj.{Helpers.GetName(collectionType.Type.Name, options.ClassNameConstantsToRemove)}(cons.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}[i], overrideObj);");
 
                 sb.AppendLine("\t\t\t}");
             }
             else
             {
                 sb.AppendLine(
-                    $"\t\t\tthis.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}[i] = cons.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}[i];");
+                    $"\t\t\tthis.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}[i] = cons.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}[i];");
             }
             sb.AppendLine("\t\t}");
             sb.AppendLine("\t}");
@@ -378,12 +370,12 @@ namespace Castle.Sharp2Js
         /// <param name="options">The options.</param>
         private static void BuildDictionaryProperty(StringBuilder sb, PropertyBag propEntry, JsGeneratorOptions options)
         {
-            sb.AppendLine($"\tthis.{ToCamelCase(propEntry.PropertyName, options.CamelCase)} = {{}};");
-            sb.AppendLine($"\tif(cons.{ToCamelCase(propEntry.PropertyName, options.CamelCase)} != null) {{");
+            sb.AppendLine($"\tthis.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)} = {{}};");
+            sb.AppendLine($"\tif(cons.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)} != null) {{");
             sb.AppendLine(
-                $"\t\tfor (var key in cons.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}) {{");
+                $"\t\tfor (var key in cons.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}) {{");
             sb.AppendLine(
-                $"\t\t\tif (cons.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}.hasOwnProperty(key)) {{");
+                $"\t\t\tif (cons.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}.hasOwnProperty(key)) {{");
 
             var keyType = propEntry.CollectionInnerTypes.First(p => p.IsDictionaryKey);
             if (!AllowedDictionaryKeyTypes.Contains(keyType.Type))
@@ -396,340 +388,23 @@ namespace Castle.Sharp2Js
             if (!valueType.IsPrimitiveType)
             {
                 sb.AppendLine(
-                    $"\t\t\t\tif (!overrideObj.{GetName(valueType.Type.Name, options.ClassNameConstantsToRemove)}) {{");
+                    $"\t\t\t\tif (!overrideObj.{Helpers.GetName(valueType.Type.Name, options.ClassNameConstantsToRemove)}) {{");
                 sb.AppendLine(
-                    $"\t\t\t\t\tthis.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}[key] = new {options.OutputNamespace}.{GetName(valueType.Type.Name, options.ClassNameConstantsToRemove)}(cons.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}[key]);");
+                    $"\t\t\t\t\tthis.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}[key] = new {options.OutputNamespace}.{Helpers.GetName(valueType.Type.Name, options.ClassNameConstantsToRemove)}(cons.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}[key]);");
                 sb.AppendLine("\t\t\t\t} else {");
                 sb.AppendLine(
-                    $"\t\t\t\t\tthis.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}[key] = new overrideObj.{GetName(valueType.Type.Name, options.ClassNameConstantsToRemove)}(cons.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}[key], overrideObj);");
+                    $"\t\t\t\t\tthis.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}[key] = new overrideObj.{Helpers.GetName(valueType.Type.Name, options.ClassNameConstantsToRemove)}(cons.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}[key], overrideObj);");
 
                 sb.AppendLine("\t\t\t\t}");
             }
             else
             {
                 sb.AppendLine(
-                    $"\t\t\t\tthis.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}[key] = cons.{ToCamelCase(propEntry.PropertyName, options.CamelCase)}[key];");
+                    $"\t\t\t\tthis.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}[key] = cons.{Helpers.ToCamelCase(propEntry.PropertyName, options.CamelCase)}[key];");
             }
             sb.AppendLine("\t\t\t}");
             sb.AppendLine("\t\t}");
             sb.AppendLine("\t}");
-        }
-
-        /// <summary>
-        /// Gets the name, filtering out the strings provided.
-        /// </summary>
-        /// <param name="input">The input.</param>
-        /// <param name="nameFilters">The name filters.</param>
-        /// <returns></returns>
-        private static string GetName(string input, List<string> nameFilters)
-        {
-            return nameFilters == null
-                ? input
-                : nameFilters.Aggregate(input, (current, nameFilter) => current.Replace(nameFilter, string.Empty));
-        }
-
-        /// <summary>
-        /// Camel cases an input string.
-        /// </summary>
-        /// <param name="input">The string.</param>
-        /// <param name="camelCase">if set to <c>true</c> [camel case].</param>
-        /// <returns></returns>
-        private static string ToCamelCase(string input, bool camelCase)
-        {
-            if (!camelCase) return input;
-
-            var s = input;
-            if (!char.IsUpper(s[0])) return s;
-
-            var cArr = s.ToCharArray();
-            for (var i = 0; i < cArr.Length; i++)
-            {
-                if (i > 0 && i + 1 < cArr.Length && !char.IsUpper(cArr[i + 1])) break;
-                cArr[i] = char.ToLowerInvariant(cArr[i]);
-            }
-            return new string(cArr);
-        }
-
-        /// <summary>
-        /// Gets the property dictionary to be used for type generation.
-        /// </summary>
-        /// <param name="types">The types to generate property information for.</param>
-        /// <param name="generatorOptions">The generator options.</param>
-        /// <param name="propertyTypeCollection">The output collection of properties discovered through reflection of the supplied classes.</param>
-        /// <returns></returns>
-        private static IEnumerable<PropertyBag> GetPropertyDictionaryForTypeGeneration(IEnumerable<Type> types,
-            JsGeneratorOptions generatorOptions,
-            List<PropertyBag> propertyTypeCollection = null)
-        {
-            if (propertyTypeCollection == null)
-            {
-                propertyTypeCollection = new List<PropertyBag>();
-            }
-            foreach (var type in types)
-            {
-                if (type.IsEnum)
-                {
-                    var getVals = type.GetEnumNames();
-                    var typeName = type.Name;
-                    var index = 0;
-                    foreach (var enumVal in getVals)
-                    {
-                        if (generatorOptions.TreatEnumsAsStrings)
-                        {
-                            propertyTypeCollection.Add(new PropertyBag(typeName, type, enumVal, typeof (string),
-                                null, PropertyBag.TransformablePropertyTypeEnum.Primitive, true, enumVal));
-                        }
-                        else
-                        {
-                            var trueVal = Convert.ChangeType(Enum.Parse(type, enumVal), type.GetEnumUnderlyingType());
-                            propertyTypeCollection.Add(new PropertyBag(typeName, type, enumVal, type.GetEnumUnderlyingType(),
-                                null, PropertyBag.TransformablePropertyTypeEnum.Primitive, true, trueVal));
-                            //if (int.TryParse(Enum(type, enumVal), out intVal))
-                        }
-
-                        index++;
-                    }
-                    
-
-                }
-                else
-                {
-                    var props = type.GetProperties();
-                    var typeName = type.Name;
-                    foreach (var prop in props)
-                    {
-                        if (!ShouldGenerateMember(prop, generatorOptions)) continue;
-
-                        var propertyName = GetPropertyName(prop, generatorOptions);
-                        var propertyType = prop.PropertyType;
-
-                        if (!IsPrimitive(propertyType))
-                        {
-                            if (IsCollectionType(propertyType))
-                            {
-                                var collectionInnerTypes = GetCollectionInnerTypes(propertyType);
-                                var isDictionaryType = IsDictionaryType(propertyType);
-
-                                propertyTypeCollection.Add(new PropertyBag(typeName, type, propertyName, propertyType,
-                                    collectionInnerTypes, isDictionaryType
-                                        ? PropertyBag.TransformablePropertyTypeEnum.DictionaryType
-                                        : PropertyBag.TransformablePropertyTypeEnum.CollectionType, false, null));
-
-                                //if primitive, no need to reflect type
-                                if (collectionInnerTypes.All(p => p.IsPrimitiveType)) continue;
-
-                                foreach (var collectionInnerType in collectionInnerTypes.Where(p => !p.IsPrimitiveType))
-                                {
-
-                                    if (propertyTypeCollection.All(p => p.TypeName != collectionInnerType.Type.Name))
-                                    {
-                                        propertyTypeCollection.AddRange(
-                                            GetPropertyDictionaryForTypeGeneration(new[] {collectionInnerType.Type},
-                                                generatorOptions, propertyTypeCollection));
-                                    }
-                                }
-                            }
-                            else
-                            {
-                                propertyTypeCollection.Add(new PropertyBag(typeName, type, propertyName, propertyType,
-                                    null, PropertyBag.TransformablePropertyTypeEnum.ReferenceType, false, null));
-
-                                if (propertyTypeCollection.All(p => p.TypeName != propertyType.Name))
-                                {
-                                    propertyTypeCollection.AddRange(
-                                        GetPropertyDictionaryForTypeGeneration(new[] {propertyType},
-                                            generatorOptions, propertyTypeCollection));
-                                }
-                            }
-                        }
-                        else
-                        {
-                            var hasDefaultValue = HasDefaultValue(prop, generatorOptions);
-                            if (hasDefaultValue)
-                            {
-                                var val = ReadDefaultValueFromAttribute(prop);
-                                propertyTypeCollection.Add(new PropertyBag(typeName, type, propertyName, propertyType,
-                                    null, PropertyBag.TransformablePropertyTypeEnum.Primitive, true, val));
-                            }
-                            else
-                            {
-                                propertyTypeCollection.Add(new PropertyBag(typeName, type, propertyName, propertyType,
-                                    null, PropertyBag.TransformablePropertyTypeEnum.Primitive, false, null));
-                            }
-
-                            if (propertyType.IsEnum)
-                            {
-                                if (propertyTypeCollection.All(p => p.TypeName != propertyType.Name))
-                                {
-                                    propertyTypeCollection.AddRange(
-                                        GetPropertyDictionaryForTypeGeneration(new[] {propertyType},
-                                            generatorOptions, propertyTypeCollection));
-                                }
-                            }
-
-                        }
-                    }
-                }
-            }
-            return propertyTypeCollection;
-        }
-
-        /// <summary>
-        /// Gets inner types of collections and dictionaries.
-        /// </summary>
-        /// <param name="propertyType">Type of the property.</param>
-        /// <returns></returns>
-        private static List<PropertyBagTypeInfo> GetCollectionInnerTypes(Type propertyType)
-        {
-            if (propertyType.IsArray)
-            {
-                return new List<PropertyBagTypeInfo>()
-                {
-                    new PropertyBagTypeInfo()
-                    {
-                        Type = propertyType.GetElementType(),
-                        IsPrimitiveType = IsPrimitive(propertyType.GetElementType()),
-                        IsEnumType = propertyType.IsEnum
-                    }
-                };
-            }
-
-            if (IsDictionaryType(propertyType))
-            {
-                return new List<PropertyBagTypeInfo>()
-                {
-                    new PropertyBagTypeInfo()
-                    {
-                        Type = propertyType.GetGenericArguments()[0],
-                        IsPrimitiveType = IsPrimitive(propertyType.GetGenericArguments()[0]),
-                        IsDictionaryKey = true,
-                        IsEnumType = propertyType.GetGenericArguments()[0].IsEnum
-                    },
-                    new PropertyBagTypeInfo()
-                    {
-                        Type = propertyType.GetGenericArguments()[1],
-                        IsPrimitiveType = IsPrimitive(propertyType.GetGenericArguments()[1]),
-                        IsEnumType = propertyType.GetGenericArguments()[1].IsEnum
-                    }
-                };
-            }
-
-            return new List<PropertyBagTypeInfo>()
-            {
-                new PropertyBagTypeInfo()
-                {
-                    Type =
-                        propertyType.GetGenericArguments().Any()
-                            ? propertyType.GetGenericArguments()[0]
-                            : typeof (string),
-                    IsPrimitiveType =
-                        IsPrimitive(propertyType.GetGenericArguments().Any()
-                            ? propertyType.GetGenericArguments()[0]
-                            : typeof (string)),
-                    IsEnumType = (propertyType.GetGenericArguments().Any()
-                            ? propertyType.GetGenericArguments()[0]
-                            : typeof (string)).IsEnum
-                }
-            };
-        }
-
-        /// <summary>
-        /// Determines whether the specified property type is a collection.
-        /// </summary>
-        /// <param name="propertyType">Type of the property.</param>
-        /// <returns></returns>
-        private static bool IsCollectionType(Type propertyType)
-        {
-
-            return (propertyType.GetInterfaces().Contains(typeof(IList)) ||
-                    propertyType.GetInterfaces().Contains(typeof(ICollection)) ||
-                    propertyType.GetInterfaces().Contains(typeof(IDictionary)) ||
-                    propertyType.IsArray);
-        }
-
-        /// <summary>
-        /// Determines whether the specified property type is a dictionary.
-        /// </summary>
-        /// <param name="propertyType">Type of the property.</param>
-        /// <returns></returns>
-        private static bool IsDictionaryType(Type propertyType)
-        {
-            return (propertyType.GetInterfaces().Contains(typeof(IDictionary)));
-        }
-
-        /// <summary>
-        /// Determines whether the specified property type is primitive.
-        /// </summary>
-        /// <param name="propertyType">Type of the property.</param>
-        /// <returns></returns>
-        private static bool IsPrimitive(Type propertyType)
-        {
-            return propertyType.IsPrimitive || propertyType.IsValueType ||
-                   propertyType == typeof(string);
-        }
-
-        /// <summary>
-        /// Determines whether the property should be generated in the Js model.
-        /// </summary>
-        /// <param name="propertyInfo">The property information.</param>
-        /// <param name="generatorOptions">The generator options.</param>
-        /// <returns></returns>
-        private static bool ShouldGenerateMember(PropertyInfo propertyInfo, JsGeneratorOptions generatorOptions)
-        {
-            if (!generatorOptions.RespectDataMemberAttribute) return true;
-
-            var customAttributes = propertyInfo.GetCustomAttributes(true);
-
-            return customAttributes.All(p => (p as IgnoreDataMemberAttribute) == null);
-        }
-
-        /// <summary>
-        /// Determines whether the property has a default value specified by the DefaultValue attribute.
-        /// </summary>
-        /// <param name="propertyInfo">The property information.</param>
-        /// <param name="generatorOptions">The generator options.</param>
-        /// <returns></returns>
-        private static bool HasDefaultValue(PropertyInfo propertyInfo, JsGeneratorOptions generatorOptions)
-        {
-            if (!generatorOptions.RespectDefaultValueAttribute) return false;
-
-            var customAttributes = propertyInfo.GetCustomAttributes(true);
-
-            if (customAttributes.All(p => (p as DefaultValueAttribute) == null)) return false;
-
-            return true;
-        }
-        /// <summary>
-        /// Reads the default value from the attribute.
-        /// </summary>
-        /// <param name="propertyInfo">The property information.</param>
-        /// <returns></returns>
-        private static object ReadDefaultValueFromAttribute(PropertyInfo propertyInfo)
-        {
-            var customAttributes = propertyInfo.GetCustomAttributes(true);
-
-            var defaultValueAttribute = (DefaultValueAttribute)customAttributes.First(p => (p as DefaultValueAttribute) != null);
-
-            return defaultValueAttribute.Value;
-        }
-
-        /// <summary>
-        /// Gets the name of the property.
-        /// </summary>
-        /// <param name="propertyInfo">The property information.</param>
-        /// <param name="generatorOptions">The generator options.</param>
-        /// <returns></returns>
-        private static string GetPropertyName(PropertyInfo propertyInfo, JsGeneratorOptions generatorOptions)
-        {
-            if (!generatorOptions.RespectDataMemberAttribute) return propertyInfo.Name;
-
-            var customAttributes = propertyInfo.GetCustomAttributes(true);
-
-            if (customAttributes.All(p => (p as DataMemberAttribute) == null)) return propertyInfo.Name;
-
-            var dataMemberAttribute = (DataMemberAttribute)customAttributes.First(p => (p as DataMemberAttribute) != null);
-
-            return !string.IsNullOrWhiteSpace(dataMemberAttribute.Name) ? dataMemberAttribute.Name : propertyInfo.Name;
         }
     }
 }

--- a/Castle.Sharp2Js/JsGeneratorOptions.cs
+++ b/Castle.Sharp2Js/JsGeneratorOptions.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
 
 namespace Castle.Sharp2Js
 {
@@ -47,11 +49,19 @@ namespace Castle.Sharp2Js
         public bool RespectDataMemberAttribute { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets a value indicating whether to respect the DefaultValue attribute when present..
+        /// Gets or sets a value indicating whether to respect the DefaultValue attribute when present.
         /// </summary>
         /// <value>
         ///   <c>true</c> if [respect default value attribute]; otherwise, <c>false</c>.
         /// </value>
         public bool RespectDefaultValueAttribute { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the custom function processors that can be run per type.
+        /// </summary>
+        /// <value>
+        /// The custom function processors.
+        /// </value>
+        public List<Action<StringBuilder, IEnumerable<PropertyBag>, JsGeneratorOptions>> CustomFunctionProcessors { get; set; }
     }
 }

--- a/Castle.Sharp2Js/JsGeneratorOptions.cs
+++ b/Castle.Sharp2Js/JsGeneratorOptions.cs
@@ -63,5 +63,13 @@ namespace Castle.Sharp2Js
         /// The custom function processors.
         /// </value>
         public List<Action<StringBuilder, IEnumerable<PropertyBag>, JsGeneratorOptions>> CustomFunctionProcessors { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether enum values should be treated as strings (the default for serializers like Jil) instead of ints.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if [treat enums as strings]; otherwise, <c>false</c>.
+        /// </value>
+        public bool TreatEnumsAsStrings { get; set; }
     }
 }

--- a/Castle.Sharp2Js/Properties/AssemblyInfo.cs
+++ b/Castle.Sharp2Js/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.0.0")]

--- a/Castle.Sharp2Js/PropertyBag.cs
+++ b/Castle.Sharp2Js/PropertyBag.cs
@@ -14,13 +14,14 @@ namespace Castle.Sharp2Js
         /// Initializes a new instance of the <see cref="PropertyBag" /> class.
         /// </summary>
         /// <param name="typeName">Name of the type.</param>
+        /// <param name="typeDefinition">The type definition.</param>
         /// <param name="propertyName">Name of the property.</param>
         /// <param name="propertyType">Type of the property.</param>
         /// <param name="collectionInnerTypes">The collection inner types.</param>
         /// <param name="transformablePropertyType">Type of the transformable property.</param>
         /// <param name="hasDefaultValue">if set to <c>true</c> [has default value].</param>
         /// <param name="defaultValue">The default value.</param>
-        public PropertyBag(string typeName, string propertyName, Type propertyType,
+        public PropertyBag(string typeName, Type typeDefinition, string propertyName, Type propertyType,
             List<PropertyBagTypeInfo> collectionInnerTypes, 
             TransformablePropertyTypeEnum transformablePropertyType,
             bool hasDefaultValue, object defaultValue)
@@ -32,6 +33,7 @@ namespace Castle.Sharp2Js
             HasDefaultValue = hasDefaultValue;
             DefaultValue = defaultValue;
             TransformablePropertyType = transformablePropertyType;
+            TypeDefinition = typeDefinition;
         }
 
         /// <summary>
@@ -84,7 +86,13 @@ namespace Castle.Sharp2Js
         /// The default value.
         /// </value>
         public object DefaultValue { get; set; }
-
+        /// <summary>
+        /// Gets or sets the type definition.
+        /// </summary>
+        /// <value>
+        /// The type definition.
+        /// </value>
+        public Type TypeDefinition { get; set; }
 
         /// <summary>
         /// Transformable property types understood by sharp2Js
@@ -136,6 +144,14 @@ namespace Castle.Sharp2Js
         /// <c>true</c> if this instance is primitive type; otherwise, <c>false</c>.
         /// </value>
         public bool IsPrimitiveType { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is enum type.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance is enum type; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsEnumType { get; set; }
     }
     
 }

--- a/Castle.Sharp2Js/PropertyBag.cs
+++ b/Castle.Sharp2Js/PropertyBag.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Castle.Sharp2Js
@@ -10,36 +11,27 @@ namespace Castle.Sharp2Js
     public class PropertyBag
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="PropertyBag"/> class.
-        /// </summary>
-        public PropertyBag()
-        {
-
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="PropertyBag" /> class.
         /// </summary>
         /// <param name="typeName">Name of the type.</param>
         /// <param name="propertyName">Name of the property.</param>
         /// <param name="propertyType">Type of the property.</param>
-        /// <param name="isArray">if set to <c>true</c> [is array].</param>
-        /// <param name="propertyTypeName">Name of the property type.</param>
-        /// <param name="isPrimitiveType">if set to <c>true</c> [is primitive type].</param>
+        /// <param name="collectionInnerTypes">The collection inner types.</param>
+        /// <param name="transformablePropertyType">Type of the transformable property.</param>
         /// <param name="hasDefaultValue">if set to <c>true</c> [has default value].</param>
         /// <param name="defaultValue">The default value.</param>
         public PropertyBag(string typeName, string propertyName, Type propertyType,
-            bool isArray, string propertyTypeName, bool isPrimitiveType, bool hasDefaultValue,
-            object defaultValue)
+            List<PropertyBagTypeInfo> collectionInnerTypes, 
+            TransformablePropertyTypeEnum transformablePropertyType,
+            bool hasDefaultValue, object defaultValue)
         {
             TypeName = typeName;
             PropertyName = propertyName;
             PropertyType = propertyType;
-            IsArray = isArray;
-            PropertyTypeName = propertyTypeName;
-            IsPrimitiveType = isPrimitiveType;
+            CollectionInnerTypes = collectionInnerTypes;
             HasDefaultValue = hasDefaultValue;
             DefaultValue = defaultValue;
+            TransformablePropertyType = transformablePropertyType;
         }
 
         /// <summary>
@@ -64,26 +56,20 @@ namespace Castle.Sharp2Js
         /// </value>
         public Type PropertyType { get; set; }
         /// <summary>
-        /// Gets or sets a value indicating whether this instance is an array.
+        /// Determines what class of object the transformer treats the object as 
+        /// which determines how the pieces are treated when writing Js objects.
         /// </summary>
         /// <value>
-        ///   <c>true</c> if this instance is an array; otherwise, <c>false</c>.
+        /// The type of the transformable property.
         /// </value>
-        public bool IsArray { get; set; }
+        public TransformablePropertyTypeEnum TransformablePropertyType { get; set; }
         /// <summary>
         /// Gets or sets the name of the property type.
         /// </summary>
         /// <value>
         /// The name of the property type.
         /// </value>
-        public string PropertyTypeName { get; set; }
-        /// <summary>
-        /// Gets or sets a value indicating whether this instance is primitive type.
-        /// </summary>
-        /// <value>
-        /// <c>true</c> if this instance is primitive type; otherwise, <c>false</c>.
-        /// </value>
-        public bool IsPrimitiveType { get; set; }
+        public List<PropertyBagTypeInfo> CollectionInnerTypes { get; set; }
         /// <summary>
         /// Gets or sets a value indicating whether this instance has a default value.
         /// </summary>
@@ -98,5 +84,58 @@ namespace Castle.Sharp2Js
         /// The default value.
         /// </value>
         public object DefaultValue { get; set; }
+
+
+        /// <summary>
+        /// Transformable property types understood by sharp2Js
+        /// </summary>
+        public enum TransformablePropertyTypeEnum
+        {
+            /// <summary>
+            /// The primitive
+            /// </summary>
+            Primitive = 1,
+            /// <summary>
+            /// The collection type
+            /// </summary>
+            CollectionType = 2,
+            /// <summary>
+            /// The dictionary type
+            /// </summary>
+            DictionaryType = 3,
+            /// <summary>
+            /// The reference type
+            /// </summary>
+            ReferenceType = 4
+        }
     }
+    /// <summary>
+    /// Contains types contained within collections and designations for dictionary types
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public class PropertyBagTypeInfo
+    {
+        /// <summary>
+        /// Gets or sets the type.
+        /// </summary>
+        /// <value>
+        /// The type.
+        /// </value>
+        public Type Type { get; set; }
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is the dictionary key.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance is the dictionary key; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsDictionaryKey { get; set; }
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is primitive type.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this instance is primitive type; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsPrimitiveType { get; set; }
+    }
+    
 }

--- a/Castle.Sharp2Js/TypePropertyDictionaryGenerator.cs
+++ b/Castle.Sharp2Js/TypePropertyDictionaryGenerator.cs
@@ -1,0 +1,185 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Castle.Sharp2Js
+{
+    /// <summary>
+    /// Generates a list of property type information to be used by the Js Generator
+    /// </summary>
+    public static class TypePropertyDictionaryGenerator
+    {
+        /// <summary>
+        /// Gets the property dictionary to be used for type generation.
+        /// </summary>
+        /// <param name="types">The types to generate property information for.</param>
+        /// <param name="generatorOptions">The generator options.</param>
+        /// <param name="propertyTypeCollection">The output collection of properties discovered through reflection of the supplied classes.</param>
+        /// <returns></returns>
+        public static IEnumerable<PropertyBag> GetPropertyDictionaryForTypeGeneration(IEnumerable<Type> types,
+            JsGeneratorOptions generatorOptions,
+            List<PropertyBag> propertyTypeCollection = null)
+        {
+            if (propertyTypeCollection == null)
+            {
+                propertyTypeCollection = new List<PropertyBag>();
+            }
+            foreach (var type in types)
+            {
+                if (type.IsEnum)
+                {
+                    var getVals = type.GetEnumNames();
+                    var typeName = type.Name;
+                    foreach (var enumVal in getVals)
+                    {
+                        if (generatorOptions.TreatEnumsAsStrings)
+                        {
+                            propertyTypeCollection.Add(new PropertyBag(typeName, type, enumVal, typeof (string),
+                                null, PropertyBag.TransformablePropertyTypeEnum.Primitive, true, enumVal));
+                        }
+                        else
+                        {
+                            var trueVal = Convert.ChangeType(Enum.Parse(type, enumVal), type.GetEnumUnderlyingType());
+                            propertyTypeCollection.Add(new PropertyBag(typeName, type, enumVal, type.GetEnumUnderlyingType(),
+                                null, PropertyBag.TransformablePropertyTypeEnum.Primitive, true, trueVal));
+                        }
+                    }
+                }
+                else
+                {
+                    var props = type.GetProperties();
+                    var typeName = type.Name;
+                    foreach (var prop in props)
+                    {
+                        if (!Helpers.ShouldGenerateMember(prop, generatorOptions)) continue;
+
+                        var propertyName = Helpers.GetPropertyName(prop, generatorOptions);
+                        var propertyType = prop.PropertyType;
+
+                        if (!Helpers.IsPrimitive(propertyType))
+                        {
+                            if (Helpers.IsCollectionType(propertyType))
+                            {
+                                var collectionInnerTypes = GetCollectionInnerTypes(propertyType);
+                                var isDictionaryType = Helpers.IsDictionaryType(propertyType);
+
+                                propertyTypeCollection.Add(new PropertyBag(typeName, type, propertyName, propertyType,
+                                    collectionInnerTypes, isDictionaryType
+                                        ? PropertyBag.TransformablePropertyTypeEnum.DictionaryType
+                                        : PropertyBag.TransformablePropertyTypeEnum.CollectionType, false, null));
+
+                                //if primitive, no need to reflect type
+                                if (collectionInnerTypes.All(p => p.IsPrimitiveType)) continue;
+
+                                foreach (var collectionInnerType in collectionInnerTypes.Where(p => !p.IsPrimitiveType))
+                                {
+
+                                    if (propertyTypeCollection.All(p => p.TypeName != collectionInnerType.Type.Name))
+                                    {
+                                        propertyTypeCollection.AddRange(GetPropertyDictionaryForTypeGeneration(new[] {collectionInnerType.Type},
+                                                generatorOptions, propertyTypeCollection));
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                propertyTypeCollection.Add(new PropertyBag(typeName, type, propertyName, propertyType,
+                                    null, PropertyBag.TransformablePropertyTypeEnum.ReferenceType, false, null));
+
+                                if (propertyTypeCollection.All(p => p.TypeName != propertyType.Name))
+                                {
+                                    propertyTypeCollection.AddRange(GetPropertyDictionaryForTypeGeneration(new[] {propertyType},
+                                            generatorOptions, propertyTypeCollection));
+                                }
+                            }
+                        }
+                        else
+                        {
+                            var hasDefaultValue = Helpers.HasDefaultValue(prop, generatorOptions);
+                            if (hasDefaultValue)
+                            {
+                                var val = Helpers.ReadDefaultValueFromAttribute(prop);
+                                propertyTypeCollection.Add(new PropertyBag(typeName, type, propertyName, propertyType,
+                                    null, PropertyBag.TransformablePropertyTypeEnum.Primitive, true, val));
+                            }
+                            else
+                            {
+                                propertyTypeCollection.Add(new PropertyBag(typeName, type, propertyName, propertyType,
+                                    null, PropertyBag.TransformablePropertyTypeEnum.Primitive, false, null));
+                            }
+
+                            if (propertyType.IsEnum)
+                            {
+                                if (propertyTypeCollection.All(p => p.TypeName != propertyType.Name))
+                                {
+                                    propertyTypeCollection.AddRange(GetPropertyDictionaryForTypeGeneration(new[] {propertyType},
+                                            generatorOptions, propertyTypeCollection));
+                                }
+                            }
+
+                        }
+                    }
+                }
+            }
+            return propertyTypeCollection;
+        }
+
+        /// <summary>
+        /// Gets inner types of collections and dictionaries.
+        /// </summary>
+        /// <param name="propertyType">Type of the property.</param>
+        /// <returns></returns>
+        private static List<PropertyBagTypeInfo> GetCollectionInnerTypes(Type propertyType)
+        {
+            if (propertyType.IsArray)
+            {
+                return new List<PropertyBagTypeInfo>()
+                {
+                    new PropertyBagTypeInfo()
+                    {
+                        Type = propertyType.GetElementType(),
+                        IsPrimitiveType = Helpers.IsPrimitive(propertyType.GetElementType()),
+                        IsEnumType = propertyType.IsEnum
+                    }
+                };
+            }
+
+            if (Helpers.IsDictionaryType(propertyType))
+            {
+                return new List<PropertyBagTypeInfo>()
+                {
+                    new PropertyBagTypeInfo()
+                    {
+                        Type = propertyType.GetGenericArguments()[0],
+                        IsPrimitiveType = Helpers.IsPrimitive(propertyType.GetGenericArguments()[0]),
+                        IsDictionaryKey = true,
+                        IsEnumType = propertyType.GetGenericArguments()[0].IsEnum
+                    },
+                    new PropertyBagTypeInfo()
+                    {
+                        Type = propertyType.GetGenericArguments()[1],
+                        IsPrimitiveType = Helpers.IsPrimitive(propertyType.GetGenericArguments()[1]),
+                        IsEnumType = propertyType.GetGenericArguments()[1].IsEnum
+                    }
+                };
+            }
+
+            return new List<PropertyBagTypeInfo>()
+            {
+                new PropertyBagTypeInfo()
+                {
+                    Type =
+                        propertyType.GetGenericArguments().Any()
+                            ? propertyType.GetGenericArguments()[0]
+                            : typeof (string),
+                    IsPrimitiveType = Helpers.IsPrimitive(propertyType.GetGenericArguments().Any()
+                        ? propertyType.GetGenericArguments()[0]
+                        : typeof (string)),
+                    IsEnumType = (propertyType.GetGenericArguments().Any()
+                        ? propertyType.GetGenericArguments()[0]
+                        : typeof (string)).IsEnum
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
Adds support for some new features:
- Supports enums (and serializer specific handling of enums)
- Supports most common collection types (`IDictionary`, `IList`, `ICollection`, `Array`)
- Supports custom function injection delegates to add custom behavior to types as needed
- Refactoring and enhancements to code readbility
- Started Wiki
- Updated Readme to point to Wiki where appropriate
